### PR TITLE
Update android security lib

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -123,9 +123,7 @@ dependencies {
 
     //other
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
-    
-    //noinspection GradleDependency // TODO(downgraded lib until the add google tink bug fix)
-    implementation "androidx.security:security-crypto:1.0.0-beta01"
+    implementation "androidx.security:security-crypto:1.0.0-rc02"
 
     api 'com.google.guava:guava:28.1-android' // TODO: this seems to be required as api for org.bitcoin.jar? Can we avoid this?
     implementation files('libs/org.bitcoin.jar')


### PR DESCRIPTION
Citing Sydney:

It looks like they fixed the bug we were running into in this release:
(Pasting from [docs](https://developer.android.com/jetpack/androidx/releases/security#security-crypto-1.0.0-rc02))
Version 1.0.0-rc02
May 20, 2020
androidx.security:security-crypto:1.0.0-rc02 is released. Version 1.0.0-rc02 contains these commits.
Bug Fixes
•	Updated to Tink version 1.4.0-rc2, which shades the proto buf lite dep. This solves the widely reported issue of clashing with other android sdks. (I8a831)
•	Fixed apply() in EncryptedSharedPreferences. (I29069, b/154366606)


**Type of change:**
- [ ] Feature work
- [X] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [X] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)