### PR TITLE
Bugfix scheme checking for deep link

### DIFF
--- a/sdk/src/main/java/com/microsoft/did/sdk/VerifiableCredentialManager.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/VerifiableCredentialManager.kt
@@ -76,11 +76,10 @@ class VerifiableCredentialManager @Inject constructor(
             return Result.Success(serializedToken)
         }
         val requestUri = uri.getQueryParameter("request_uri")
-        return if (requestUri == null) {
-            Result.Failure(PresentationException("Request Uri does not exist."))
-        } else {
-            vchRepository.getRequest(requestUri)
+        if (requestUri != null) {
+            return vchRepository.getRequest(requestUri)
         }
+        return Result.Failure(PresentationException("No query parameter 'request' nor 'request_uri' is passed."))
     }
 
     /**

--- a/sdk/src/main/java/com/microsoft/did/sdk/VerifiableCredentialManager.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/VerifiableCredentialManager.kt
@@ -70,17 +70,15 @@ class VerifiableCredentialManager @Inject constructor(
     }
 
     private suspend fun getPresentationRequestToken(uri: Uri): Result<String> {
-        return runResultTry {
-            val serializedToken = uri.getQueryParameter("request")
-            if (serializedToken != null) {
-                Result.Success(serializedToken)
-            }
-            val requestUri = uri.getQueryParameter("request_uri")
-            if (requestUri == null) {
-                Result.Failure(PresentationException("Request Uri does not exist."))
-            } else {
-                vchRepository.getRequest(requestUri)
-            }
+        val serializedToken = uri.getQueryParameter("request")
+        if (serializedToken != null) {
+            return Result.Success(serializedToken)
+        }
+        val requestUri = uri.getQueryParameter("request_uri")
+        return if (requestUri == null) {
+            Result.Failure(PresentationException("Request Uri does not exist."))
+        } else {
+            vchRepository.getRequest(requestUri)
         }
     }
 

--- a/sdk/src/main/java/com/microsoft/did/sdk/VerifiableCredentialManager.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/VerifiableCredentialManager.kt
@@ -21,6 +21,7 @@ import com.microsoft.did.sdk.credential.models.VerifiableCredential
 import com.microsoft.did.sdk.crypto.protocols.jose.jws.JwsToken
 import com.microsoft.did.sdk.identifier.models.Identifier
 import com.microsoft.did.sdk.datasource.repository.VerifiableCredentialHolderRepository
+import com.microsoft.did.sdk.util.Constants
 import com.microsoft.did.sdk.util.Constants.DEFAULT_EXPIRATION_IN_MINUTES
 import com.microsoft.did.sdk.util.serializer.Serializer
 import com.microsoft.did.sdk.util.controlflow.*
@@ -63,7 +64,7 @@ class VerifiableCredentialManager @Inject constructor(
 
     private fun verifyUri(uri: String): Uri {
         val url = Uri.parse(uri)
-        if (url.scheme != "openid") {
+        if (url.scheme != Constants.DEEP_LINK_SCHEME) {
             throw PresentationException("Request Protocol not supported.")
         }
         return url

--- a/sdk/src/main/java/com/microsoft/did/sdk/util/Constants.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/util/Constants.kt
@@ -34,6 +34,8 @@ object Constants {
     const val RESPONSE_EXPIRATION_IN_MINUTES = 600
     const val HASHING_ALGORITHM_FOR_ID = "MD5"
 
+    const val DEEP_LINK_SCHEME = "openid"
+
     //Identifier Constants
     const val MASTER_IDENTIFIER_NAME = "did.identifier"
     const val METHOD_NAME = "ion"

--- a/sdk/src/main/java/com/microsoft/did/sdk/util/Constants.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/util/Constants.kt
@@ -34,7 +34,7 @@ object Constants {
     const val RESPONSE_EXPIRATION_IN_MINUTES = 600
     const val HASHING_ALGORITHM_FOR_ID = "MD5"
 
-    const val DEEP_LINK_SCHEME = "openid"
+    const val DEEP_LINK_SCHEME = "verifiablecredential"
 
     //Identifier Constants
     const val MASTER_IDENTIFIER_NAME = "did.identifier"


### PR DESCRIPTION
Do you remember how I was ranting about the only thing I dislike in Kotlin? @symorton @nithyaganeshng Here we have a perfect example why it's bad ^^ (implicitly returning the last line of a `{ }` scope)

However, minor fix. I also added a constant for the scheme so that Authenticator can consume that.

**Type of change:**
- [ ] Feature work
- [X] Bug fix
- [ ] Documentation
- [X] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)