### PR TITLE
Update NDK version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 
-ndk_version=21.2.6472646
+ndk_version=21.3.6528147
 dagger_version=2.27
 androidx_room_persistence_version=2.2.5
 retrofit2_version=2.8.1


### PR DESCRIPTION
**Problem:**
Azure agents no longer support old NDK version, which breaks Authenticator PRs.


**Solution:**
Update NDK version.


**Validation:**
Build is passing.


**Type of change:**
- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [x] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
N/A


**Documentation Links**:
https://github.com/android/ndk/wiki/Changelog-r20