### PR TITLE
Presentation Request Protocol Change and Validator Testing

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="IllegalIdentifier" enabled="false" level="ERROR" enabled_by_default="false" />
+  </profile>
+</component>

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -134,13 +134,9 @@ dependencies {
     androidTestImplementation "io.mockk:mockk-android:1.10.0"
     androidTestImplementation "android.arch.core:core-testing:1.1.1"
 
-    def mockito_version = "3.2.4"
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
-    testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"
     testImplementation "io.mockk:mockk:1.10.0"
-    testImplementation "org.mockito:mockito-core:$mockito_version"
-    testImplementation "org.mockito:mockito-inline:$mockito_version"
     testImplementation 'com.willowtreeapps.assertk:assertk-jvm:0.21'
     testImplementation "org.assertj:assertj-core:3.11.1"
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"

--- a/sdk/src/main/java/com/microsoft/did/sdk/credential/service/validators/JwtValidator.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/credential/service/validators/JwtValidator.kt
@@ -20,7 +20,7 @@ import javax.inject.Singleton
  * Class that can be used to validate JwsTokens.
  */
 @Singleton
-class JwsValidator @Inject constructor(
+class JwtValidator @Inject constructor(
     private val cryptoOperations: CryptoOperations,
     private val resolver: Resolver,
     private val serializer: Serializer
@@ -37,7 +37,7 @@ class JwsValidator @Inject constructor(
     }
 
     private fun getKid(signature: JwsSignature): Pair<String, String> {
-        val kid = signature.getKid(serializer) ?: throw Exception("no kid specified in token")
+        val kid = signature.getKid(serializer) ?: throw ValidatorException("no kid specified in token")
         val parsedKid = kid.split("#")
         return Pair(parsedKid[0], parsedKid[1])
     }

--- a/sdk/src/main/java/com/microsoft/did/sdk/credential/service/validators/OidcPresentationRequestValidator.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/credential/service/validators/OidcPresentationRequestValidator.kt
@@ -27,9 +27,7 @@ class OidcPresentationRequestValidator @Inject constructor(
         if (!jwsValidator.verifySignature(token)) {
             throw ValidatorException("Signature is not Valid.")
         }
-        // TODO(check token expiration when implemented in sdk)
-        // checkTokenExpiration(request.content.exp)
-        checkRequestParameters(request.content, request.uri)
+        checkTokenExpiration(request.content.exp)
     }
 
     private fun checkTokenExpiration(expiration: Long) {
@@ -43,13 +41,7 @@ class OidcPresentationRequestValidator @Inject constructor(
         return currentTimeInSeconds + SECONDS_IN_A_MINUTE * expirationCheckTimeOffsetInMinutes
     }
 
-    private fun checkRequestParameters(requestContents: OidcRequestContent, uri: Uri) {
-        if (uri.getQueryParameter(CLIENT_ID) != requestContents.clientId) {
-            throw ValidatorException("Request content does not match url parameters.")
-        }
-    }
-
-    internal fun deserializeJwsToken(serializedToken: String): JwsToken {
+    private fun deserializeJwsToken(serializedToken: String): JwsToken {
         return JwsToken.deserialize(serializedToken, serializer)
     }
 }

--- a/sdk/src/main/java/com/microsoft/did/sdk/credential/service/validators/OidcPresentationRequestValidator.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/credential/service/validators/OidcPresentationRequestValidator.kt
@@ -1,14 +1,12 @@
 package com.microsoft.did.sdk.credential.service.validators
 
-import android.net.Uri
-import com.microsoft.did.sdk.util.Constants.CLIENT_ID
 import com.microsoft.did.sdk.util.Constants.MILLISECONDS_IN_A_SECOND
 import com.microsoft.did.sdk.util.Constants.SECONDS_IN_A_MINUTE
-import com.microsoft.did.sdk.credential.service.models.oidc.OidcRequestContent
 import com.microsoft.did.sdk.credential.service.PresentationRequest
 import com.microsoft.did.sdk.crypto.protocols.jose.jws.JwsToken
+import com.microsoft.did.sdk.util.controlflow.ExpiredTokenExpirationException
+import com.microsoft.did.sdk.util.controlflow.InvalidSignatureException
 import com.microsoft.did.sdk.util.serializer.Serializer
-import com.microsoft.did.sdk.util.controlflow.ValidatorException
 import java.util.*
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -18,30 +16,26 @@ import javax.inject.Singleton
  */
 @Singleton
 class OidcPresentationRequestValidator @Inject constructor(
-    private val jwsValidator: JwsValidator,
+    private val jwtValidator: JwtValidator,
     private val serializer: Serializer
 ) : PresentationRequestValidator {
 
     override suspend fun validate(request: PresentationRequest) {
-        val token = deserializeJwsToken(request.serializedToken)
-        if (!jwsValidator.verifySignature(token)) {
-            throw ValidatorException("Signature is not Valid.")
+        val token = JwsToken.deserialize(request.serializedToken, serializer)
+        if (!jwtValidator.verifySignature(token)) {
+            throw InvalidSignatureException("Signature is not Valid.")
         }
         checkTokenExpiration(request.content.exp)
     }
 
     private fun checkTokenExpiration(expiration: Long) {
         if (getExpirationDeadlineInSeconds() > expiration) {
-            throw ValidatorException("Request Token has expired.")
+            throw ExpiredTokenExpirationException("Request Token has expired.")
         }
     }
 
     private fun getExpirationDeadlineInSeconds(expirationCheckTimeOffsetInMinutes: Int = 5): Long {
         val currentTimeInSeconds = Date().time / MILLISECONDS_IN_A_SECOND
         return currentTimeInSeconds + SECONDS_IN_A_MINUTE * expirationCheckTimeOffsetInMinutes
-    }
-
-    private fun deserializeJwsToken(serializedToken: String): JwsToken {
-        return JwsToken.deserialize(serializedToken, serializer)
     }
 }

--- a/sdk/src/main/java/com/microsoft/did/sdk/util/controlflow/Exceptions.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/util/controlflow/Exceptions.kt
@@ -35,7 +35,11 @@ open class IssuanceException(message: String? = null, cause: Throwable? = null) 
 
 class PairwiseIssuanceException(message: String? = null, cause: Throwable? = null) : AuthenticationException(message, cause)
 
-class ValidatorException(message: String? = null, cause: Throwable? = null) : SdkException(message, cause)
+open class ValidatorException(message: String? = null, cause: Throwable? = null) : SdkException(message, cause)
+
+class InvalidSignatureException(message: String? = null, cause: Throwable? = null) : ValidatorException(message, cause)
+
+class ExpiredTokenExpirationException(message: String? = null, cause: Throwable? = null) : ValidatorException(message, cause)
 
 class FormatterException(message: String? = null, cause: Throwable? = null) : SdkException(message, cause)
 

--- a/sdk/src/test/java/com/microsoft/did/sdk/credential/service/validators/JwtValidatorTest.kt
+++ b/sdk/src/test/java/com/microsoft/did/sdk/credential/service/validators/JwtValidatorTest.kt
@@ -1,0 +1,114 @@
+package com.microsoft.did.sdk.credential.service.validators
+
+import com.microsoft.did.sdk.crypto.CryptoOperations
+import com.microsoft.did.sdk.crypto.keys.PublicKey
+import com.microsoft.did.sdk.crypto.protocols.jose.jws.JwsSignature
+import com.microsoft.did.sdk.crypto.protocols.jose.jws.JwsToken
+import com.microsoft.did.sdk.identifier.models.identifierdocument.IdentifierDocument
+import com.microsoft.did.sdk.identifier.models.identifierdocument.IdentifierDocumentPublicKey
+import com.microsoft.did.sdk.identifier.resolvers.Resolver
+import com.microsoft.did.sdk.util.controlflow.ExpiredTokenExpirationException
+import com.microsoft.did.sdk.util.controlflow.InvalidSignatureException
+import com.microsoft.did.sdk.util.controlflow.Result
+import com.microsoft.did.sdk.util.controlflow.ValidatorException
+import com.microsoft.did.sdk.util.serializer.Serializer
+import io.mockk.*
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import java.lang.Exception
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+class JwtValidatorTest {
+
+    private val mockedIdentifierDocument: IdentifierDocument = mockk()
+
+    private val mockedIdentifierDocumentPublicKey: IdentifierDocumentPublicKey = mockk()
+
+    private val mockedPublicKey: PublicKey = mockk()
+
+    private val mockedJwsToken: JwsToken = mockk()
+
+    private val mockedCryptoOperations: CryptoOperations = mockk()
+
+    private val mockedJwsTokenSignature: JwsSignature = mockk()
+
+    private val mockedResolver: Resolver = mockk()
+
+    private val expectedSerializedToken: String = "token2364302"
+
+    private val validator: JwtValidator
+    private val serializer: Serializer = Serializer()
+
+    private val expectedSignature: String = "signature4234"
+    private val expectedDid: String = "did:test:4235"
+    private val expectedKid: String = "$expectedDid#kidTest2353"
+
+
+    init {
+        validator = JwtValidator(mockedCryptoOperations, mockedResolver, serializer)
+        every { mockedJwsToken.signatures } returns mutableListOf(mockedJwsTokenSignature)
+        setUpResolver()
+        mockkObject(JwsToken)
+    }
+
+    private fun setUpResolver() {
+        every { mockedIdentifierDocument.publicKey } returns listOf(mockedIdentifierDocumentPublicKey)
+        every { mockedIdentifierDocumentPublicKey.toPublicKey() } returns mockedPublicKey
+    }
+
+    @Test
+    fun validateSignatureTest() {
+        coEvery { mockedResolver.resolve(expectedDid) } returns Result.Success(mockedIdentifierDocument)
+        every { mockedJwsTokenSignature.getKid(serializer) } returns expectedKid
+        every { mockedJwsToken.verify(mockedCryptoOperations, listOf(mockedPublicKey)) } returns true
+        runBlocking {
+            val actualValidationResult = validator.verifySignature(mockedJwsToken)
+            assertTrue(actualValidationResult)
+        }
+    }
+
+    @Test
+    fun invalidSignatureFailureTest() {
+        coEvery { mockedResolver.resolve(expectedDid) } returns Result.Success(mockedIdentifierDocument)
+        every { mockedJwsTokenSignature.getKid(serializer) } returns expectedKid
+        every { mockedJwsToken.verify(mockedCryptoOperations, listOf(mockedPublicKey)) } returns false
+        runBlocking {
+            val actualValidationResult = validator.verifySignature(mockedJwsToken)
+            assertFalse(actualValidationResult)
+        }
+    }
+
+    @Test
+    fun noKidSpecifiedFailureTest() {
+        coEvery { mockedResolver.resolve(expectedDid) } returns Result.Success(mockedIdentifierDocument)
+        every { mockedJwsTokenSignature.getKid(serializer) } returns null
+        every { mockedJwsToken.verify(mockedCryptoOperations, listOf(mockedPublicKey)) } returns true
+        runBlocking {
+            try {
+                validator.verifySignature(mockedJwsToken)
+                fail()
+            } catch(exception: Exception) {
+                assertThat(exception).isInstanceOf(ValidatorException::class.java)
+            }
+        }
+    }
+
+    @Test
+    fun didResolutionFailureTest() {
+        val expectedException = ValidatorException("test")
+        coEvery { mockedResolver.resolve(expectedDid) } returns Result.Failure(expectedException)
+        every { mockedJwsTokenSignature.getKid(serializer) } returns expectedKid
+        every { mockedJwsToken.verify(mockedCryptoOperations, listOf(mockedPublicKey)) } returns true
+        runBlocking {
+            try {
+                validator.verifySignature(mockedJwsToken)
+                fail()
+            } catch(exception: Exception) {
+                assertThat(exception).isInstanceOf(ValidatorException::class.java)
+            }
+        }
+    }
+}

--- a/sdk/src/test/java/com/microsoft/did/sdk/credential/service/validators/JwtValidatorTest.kt
+++ b/sdk/src/test/java/com/microsoft/did/sdk/credential/service/validators/JwtValidatorTest.kt
@@ -60,7 +60,7 @@ class JwtValidatorTest {
     }
 
     @Test
-    fun `validSignatureIsValidatedSuccessfully`() {
+    fun `valid signature is validated successfully`() {
         coEvery { mockedResolver.resolve(expectedDid) } returns Result.Success(mockedIdentifierDocument)
         every { mockedJwsTokenSignature.getKid(serializer) } returns expectedKid
         every { mockedJwsToken.verify(mockedCryptoOperations, listOf(mockedPublicKey)) } returns true
@@ -71,7 +71,7 @@ class JwtValidatorTest {
     }
 
     @Test
-    fun `invalidSignatureFailsSuccessfully`() {
+    fun `invalid signature fails successfully`() {
         coEvery { mockedResolver.resolve(expectedDid) } returns Result.Success(mockedIdentifierDocument)
         every { mockedJwsTokenSignature.getKid(serializer) } returns expectedKid
         every { mockedJwsToken.verify(mockedCryptoOperations, listOf(mockedPublicKey)) } returns false
@@ -82,7 +82,7 @@ class JwtValidatorTest {
     }
 
     @Test
-    fun `throwsWhenNoKeyIdSpecified`() {
+    fun `throws when no key id specified`() {
         coEvery { mockedResolver.resolve(expectedDid) } returns Result.Success(mockedIdentifierDocument)
         every { mockedJwsTokenSignature.getKid(serializer) } returns null
         every { mockedJwsToken.verify(mockedCryptoOperations, listOf(mockedPublicKey)) } returns true
@@ -97,7 +97,7 @@ class JwtValidatorTest {
     }
 
     @Test
-    fun `throwsWhenUnableToResolveIdentifierDocument`() {
+    fun `throws when unable to resolve identifier document`() {
         val expectedException = ValidatorException("test")
         coEvery { mockedResolver.resolve(expectedDid) } returns Result.Failure(expectedException)
         every { mockedJwsTokenSignature.getKid(serializer) } returns expectedKid

--- a/sdk/src/test/java/com/microsoft/did/sdk/credential/service/validators/JwtValidatorTest.kt
+++ b/sdk/src/test/java/com/microsoft/did/sdk/credential/service/validators/JwtValidatorTest.kt
@@ -60,7 +60,7 @@ class JwtValidatorTest {
     }
 
     @Test
-    fun validateSignatureTest() {
+    fun `validSignatureIsValidatedSuccessfully`() {
         coEvery { mockedResolver.resolve(expectedDid) } returns Result.Success(mockedIdentifierDocument)
         every { mockedJwsTokenSignature.getKid(serializer) } returns expectedKid
         every { mockedJwsToken.verify(mockedCryptoOperations, listOf(mockedPublicKey)) } returns true
@@ -71,7 +71,7 @@ class JwtValidatorTest {
     }
 
     @Test
-    fun invalidSignatureFailureTest() {
+    fun `invalidSignatureFailsSuccessfully`() {
         coEvery { mockedResolver.resolve(expectedDid) } returns Result.Success(mockedIdentifierDocument)
         every { mockedJwsTokenSignature.getKid(serializer) } returns expectedKid
         every { mockedJwsToken.verify(mockedCryptoOperations, listOf(mockedPublicKey)) } returns false
@@ -82,7 +82,7 @@ class JwtValidatorTest {
     }
 
     @Test
-    fun noKidSpecifiedFailureTest() {
+    fun `throwsWhenNoKeyIdSpecified`() {
         coEvery { mockedResolver.resolve(expectedDid) } returns Result.Success(mockedIdentifierDocument)
         every { mockedJwsTokenSignature.getKid(serializer) } returns null
         every { mockedJwsToken.verify(mockedCryptoOperations, listOf(mockedPublicKey)) } returns true
@@ -97,7 +97,7 @@ class JwtValidatorTest {
     }
 
     @Test
-    fun didResolutionFailureTest() {
+    fun `throwsWhenUnableToResolveIdentifierDocument`() {
         val expectedException = ValidatorException("test")
         coEvery { mockedResolver.resolve(expectedDid) } returns Result.Failure(expectedException)
         every { mockedJwsTokenSignature.getKid(serializer) } returns expectedKid

--- a/sdk/src/test/java/com/microsoft/did/sdk/credential/service/validators/OidcPresentationRequestValidatorTest.kt
+++ b/sdk/src/test/java/com/microsoft/did/sdk/credential/service/validators/OidcPresentationRequestValidatorTest.kt
@@ -60,7 +60,7 @@ class OidcPresentationRequestValidatorTest {
     }
 
     @Test
-    fun validatePresentationRequestTest() {
+    fun `validSignatureIsValidatedSuccessfully`() {
         setUpExpiration(86400)
         every { JwsToken.deserialize(expectedSerializedToken, serializer) } returns mockedJwsToken
         coEvery { mockedJwtValidator.verifySignature(mockedJwsToken) } returns true
@@ -70,7 +70,7 @@ class OidcPresentationRequestValidatorTest {
     }
 
     @Test
-    fun invalidSignatureFailureTest() {
+    fun `invalidSignatureFailsSuccessfully`() {
         setUpExpiration(86400)
         every { JwsToken.deserialize(expectedSerializedToken, serializer) } returns mockedJwsToken
         coEvery { mockedJwtValidator.verifySignature(mockedJwsToken) } returns false
@@ -85,7 +85,7 @@ class OidcPresentationRequestValidatorTest {
     }
 
     @Test
-    fun expiredExpirationTest() {
+    fun `throwsWhenTokenExpirationIsExpired`() {
         setUpExpiration(-86400)
         every { JwsToken.deserialize(expectedSerializedToken, serializer) } returns mockedJwsToken
         coEvery { mockedJwtValidator.verifySignature(mockedJwsToken) } returns true

--- a/sdk/src/test/java/com/microsoft/did/sdk/credential/service/validators/OidcPresentationRequestValidatorTest.kt
+++ b/sdk/src/test/java/com/microsoft/did/sdk/credential/service/validators/OidcPresentationRequestValidatorTest.kt
@@ -1,71 +1,101 @@
 package com.microsoft.did.sdk.credential.service.validators
 
 import android.net.Uri
-import com.microsoft.did.sdk.credential.service.models.oidc.OidcRequestContent
 import com.microsoft.did.sdk.credential.service.PresentationRequest
-import com.microsoft.did.sdk.crypto.CryptoOperations
-import com.microsoft.did.sdk.crypto.keys.PublicKey
+import com.microsoft.did.sdk.credential.service.models.oidc.OidcRequestContent
 import com.microsoft.did.sdk.crypto.protocols.jose.jws.JwsToken
 import com.microsoft.did.sdk.identifier.models.Identifier
+import com.microsoft.did.sdk.util.Constants
+import com.microsoft.did.sdk.util.controlflow.ExpiredTokenExpirationException
+import com.microsoft.did.sdk.util.controlflow.InvalidSignatureException
 import com.microsoft.did.sdk.util.serializer.Serializer
-import org.junit.Before
-import org.mockito.ArgumentMatchers
-import org.mockito.Mock
-import org.mockito.Mockito.`when`
-import org.mockito.MockitoAnnotations
+import io.mockk.*
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import java.util.*
+import kotlin.test.fail
 
 class OidcPresentationRequestValidatorTest {
 
-    @Mock
-    lateinit var mockedPresentationRequest: PresentationRequest
-    @Mock
-    lateinit var mockedJwsToken: JwsToken
-    @Mock
-    lateinit var mockedJwsValidator: JwsValidator
-    @Mock
-    lateinit var mockedCryptoOperations: CryptoOperations
-    @Mock
-    lateinit var mockedPublicKey: PublicKey
-    @Mock
-    lateinit var mockedUri: Uri
+    private val mockedPresentationRequest: PresentationRequest = mockk()
 
-    lateinit var validator: OidcPresentationRequestValidator
+    private val mockedJwsToken: JwsToken = mockk()
 
-    private val signingKeyRef: String = "sigKeyRef1243523"
-    private val did: String = "did:test:2354543"
-    private val audience: String = "audience2432"
-    private val mockedSerializedToken: String = "token2364302"
-    private val clientId: String = "clientId12453"
-    private val serializer: Serializer =
-        Serializer()
-    private val mockedIdentifier = Identifier(
-        did,
-        "",
-        signingKeyRef,
-        "",
-        "",
-        "",
-        ""
-    )
+    private val mockedJwtValidator: JwtValidator = mockk()
 
-    @Before
-    fun setUp() {
-        MockitoAnnotations.initMocks(this)
-        validator = OidcPresentationRequestValidator(mockedJwsValidator, serializer)
+    private val mockedOidcRequestContent: OidcRequestContent = mockk()
+
+    private val mockedIdentifier: Identifier = mockk()
+
+    private val expectedSerializedToken: String = "token2364302"
+
+    private val validator: OidcPresentationRequestValidator
+    private val serializer: Serializer = Serializer()
+
+    private val expectedSigningKeyRef: String = "sigKeyRef1243523"
+    private val expectedDid: String = "did:test:2354543"
+
+    init {
+        validator = OidcPresentationRequestValidator(mockedJwtValidator, serializer)
         setUpPresentationRequest()
-        `when`<String>(mockedPresentationRequest.serializedToken).thenReturn(mockedSerializedToken)
-        `when`<Boolean>(mockedJwsToken.verify(mockedCryptoOperations, listOf(mockedPublicKey))).thenReturn(true)
+        setUpIdentifier()
+        mockkObject(JwsToken)
     }
 
     private fun setUpPresentationRequest() {
-        `when`<String>(mockedPresentationRequest.serializedToken).thenReturn(mockedSerializedToken)
-        `when`<OidcRequestContent>(mockedPresentationRequest.content).thenReturn(OidcRequestContent(clientId = clientId))
-        `when`<Uri>(mockedPresentationRequest.uri).thenReturn(mockedUri)
-        `when`<String>(mockedUri.getQueryParameter(ArgumentMatchers.anyString())).thenReturn(clientId)
+        every { mockedPresentationRequest.serializedToken } returns expectedSerializedToken
+        every { mockedPresentationRequest.content } returns mockedOidcRequestContent
     }
 
-//    @Test
-//    fun `validate a presentation request`() {
-//        TODO("not implemented")
-//    }
+    private fun setUpIdentifier() {
+        every { mockedIdentifier.signatureKeyReference } returns expectedSigningKeyRef
+        every { mockedIdentifier.id } returns expectedDid
+    }
+
+    private fun setUpExpiration(offsetInSecond: Long) {
+        val currentTimeInSeconds: Long = Date().time / Constants.MILLISECONDS_IN_A_SECOND
+        val currentTimePlusOffsetInSeconds = currentTimeInSeconds + offsetInSecond
+        every { mockedOidcRequestContent.exp } returns currentTimePlusOffsetInSeconds
+    }
+
+    @Test
+    fun validatePresentationRequestTest() {
+        setUpExpiration(86400)
+        every { JwsToken.deserialize(expectedSerializedToken, serializer) } returns mockedJwsToken
+        coEvery { mockedJwtValidator.verifySignature(mockedJwsToken) } returns true
+        runBlocking {
+                validator.validate(mockedPresentationRequest)
+        }
+    }
+
+    @Test
+    fun invalidSignatureFailureTest() {
+        setUpExpiration(86400)
+        every { JwsToken.deserialize(expectedSerializedToken, serializer) } returns mockedJwsToken
+        coEvery { mockedJwtValidator.verifySignature(mockedJwsToken) } returns false
+        runBlocking {
+            try {
+                validator.validate(mockedPresentationRequest)
+                fail()
+            } catch (exception: Exception) {
+                assertThat(exception).isInstanceOf(InvalidSignatureException::class.java)
+            }
+        }
+    }
+
+    @Test
+    fun expiredExpirationTest() {
+        setUpExpiration(-86400)
+        every { JwsToken.deserialize(expectedSerializedToken, serializer) } returns mockedJwsToken
+        coEvery { mockedJwtValidator.verifySignature(mockedJwsToken) } returns true
+        runBlocking {
+            try {
+                validator.validate(mockedPresentationRequest)
+                fail()
+            } catch (exception: Exception) {
+                assertThat(exception).isInstanceOf(ExpiredTokenExpirationException::class.java)
+            }
+        }
+    }
 }

--- a/sdk/src/test/java/com/microsoft/did/sdk/credential/service/validators/OidcPresentationRequestValidatorTest.kt
+++ b/sdk/src/test/java/com/microsoft/did/sdk/credential/service/validators/OidcPresentationRequestValidatorTest.kt
@@ -60,7 +60,7 @@ class OidcPresentationRequestValidatorTest {
     }
 
     @Test
-    fun `validSignatureIsValidatedSuccessfully`() {
+    fun `valid signature is validated successfully`() {
         setUpExpiration(86400)
         every { JwsToken.deserialize(expectedSerializedToken, serializer) } returns mockedJwsToken
         coEvery { mockedJwtValidator.verifySignature(mockedJwsToken) } returns true
@@ -70,7 +70,7 @@ class OidcPresentationRequestValidatorTest {
     }
 
     @Test
-    fun `invalidSignatureFailsSuccessfully`() {
+    fun `invalid signature fails successfully`() {
         setUpExpiration(86400)
         every { JwsToken.deserialize(expectedSerializedToken, serializer) } returns mockedJwsToken
         coEvery { mockedJwtValidator.verifySignature(mockedJwsToken) } returns false
@@ -85,7 +85,7 @@ class OidcPresentationRequestValidatorTest {
     }
 
     @Test
-    fun `throwsWhenTokenExpirationIsExpired`() {
+    fun `throws when token expiration is expired`() {
         setUpExpiration(-86400)
         every { JwsToken.deserialize(expectedSerializedToken, serializer) } returns mockedJwsToken
         coEvery { mockedJwtValidator.verifySignature(mockedJwsToken) } returns true


### PR DESCRIPTION
**Problem:**
QR code was too long, so Relying Parties are not using client_id parameter in QR code or Deep Link urls. 

**Solution:**
- Delete param check in `OidcPresentationRequestValidator` class
- Add tests for both `OidcPresentationRequestValidator` and `JwtValidator` classes using mockk
- Remove dependency on Mockito

**Validation:**
- Unit tests pass

**Type of change:**
- [ ] Feature work
- [X] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [X] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)

**Work Item links**:
[Client ID Bug](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1056213)

**Documentation Links**:
Please include here links to any related background documentation for this PR.