### PR TITLE
Cleanup println statements

### DIFF
--- a/sdk/src/main/java/com/microsoft/did/sdk/crypto/protocols/jose/JwaCryptoConverter.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/crypto/protocols/jose/JwaCryptoConverter.kt
@@ -33,46 +33,28 @@ object JwaCryptoConverter {
                 val hashSize = Regex("[Rr][Ss](\\d+)").matchEntire(algorithm)!!.groupValues[0]
                 Algorithm(
                     name = W3cCryptoApiConstants.RsaSsaPkcs1V15.value,
-                    additionalParams = mapOf(
-                        "hash" to Sha.get(hashSize.toInt())
-                    )
+                    additionalParams = mapOf("hash" to Sha.get(hashSize.toInt()))
                 )
             }
             JoseConstants.RsaOaep.value, JoseConstants.RsaOaep256.value -> {
                 RsaOaepParams(
-                    additionalParams = mapOf(
-                        "hash" to Algorithm(
-                            name = W3cCryptoApiConstants.Sha256.value
-                        )
-                    )
+                    additionalParams = mapOf("hash" to Algorithm(name = W3cCryptoApiConstants.Sha256.value))
                 )
             }
             JoseConstants.EcDsa.value, JoseConstants.Es256K.value -> {
                 EcdsaParams(
-                    hash = Algorithm(
-                        name = W3cCryptoApiConstants.Sha256.value
-                    ),
-                    additionalParams = mapOf(
-                        "namedCurve" to W3cCryptoApiConstants.Secp256k1.value
+                    hash = Algorithm(name = W3cCryptoApiConstants.Sha256.value),
+                    additionalParams = mapOf("namedCurve" to W3cCryptoApiConstants.Secp256k1.value
                     )
                 )
             }
             JoseConstants.EdDsa.value -> {
                 EcdsaParams(
-                    hash = Algorithm(
-                        name = W3cCryptoApiConstants.Sha256.value
-                    ),
-                    additionalParams = mapOf(
-                        "namedCurve" to W3cCryptoApiConstants.Ed25519.value
-                    )
+                    hash = Algorithm(name = W3cCryptoApiConstants.Sha256.value),
+                    additionalParams = mapOf("namedCurve" to W3cCryptoApiConstants.Ed25519.value)
                 )
             }
-            else -> {
-                println("Unknown JOSE algorithm: $algorithm")
-                Algorithm(
-                    name = algorithm
-                )
-            }
+            else -> Algorithm(name = algorithm)
         }
     }
 

--- a/sdk/src/main/java/com/microsoft/did/sdk/crypto/protocols/jose/jws/JwsToken.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/crypto/protocols/jose/jws/JwsToken.kt
@@ -239,7 +239,6 @@ class JwsToken private constructor(
         )
         val rawSignature = Base64Url.decode(signature.signature)
         val rawData = stringToByteArray(data)
-        SdkLog.d("Raw data: " + rawData.toReadableString())
         return subtle.verify(subtleAlg, cryptoKey, rawSignature, rawData)
     }
 

--- a/sdk/src/main/java/com/microsoft/did/sdk/crypto/protocols/jose/jws/JwsToken.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/crypto/protocols/jose/jws/JwsToken.kt
@@ -36,7 +36,6 @@ class JwsToken private constructor(
             when {
                 compactMatches != null -> {
                     // compact JWS format
-                    println("Compact format detected")
                     val protected = compactMatches.groupValues[1]
                     val payload = compactMatches.groupValues[2]
                     val signature = compactMatches.groupValues[3]
@@ -49,7 +48,6 @@ class JwsToken private constructor(
                 }
                 jws.toLowerCase(Locale.ENGLISH).contains("\"signatures\"") -> { // check for signature or signatures
                     // GENERAL
-                    println("General format detected")
                     val token = serializer.parse(JwsGeneralJson.serializer(), jws)
                     return JwsToken(
                         payload = token.payload,
@@ -59,7 +57,6 @@ class JwsToken private constructor(
                 }
                 jws.toLowerCase(Locale.ENGLISH).contains("\"signature\"") -> {
                     // Flat
-                    println("Flat format detected")
                     val token = serializer.parse(JwsFlatJson.serializer(), jws)
                     return JwsToken(
                         payload = token.payload,
@@ -166,7 +163,6 @@ class JwsToken private constructor(
         val kid = headers[JoseConstants.Kid.value]
         if (kid == null) {
             protected[JoseConstants.Kid.value] = signingKey.kid
-            println("Using key ${protected[JoseConstants.Kid.value]}")
         } else {
             protected[JoseConstants.Kid.value] = kid
         }
@@ -202,12 +198,9 @@ class JwsToken private constructor(
         val results = this.signatures.map {
             val fullyQuantifiedKid = it.getKid(serializer) ?: ""
             val kid = JwaCryptoConverter.extractDidAndKeyId(fullyQuantifiedKid).second
-            println("Finding matching key for \"$kid\"")
             val signatureInput = "${it.protected}.${this.payload}"
-            println("SDATA: $signatureInput")
             val publicKey = cryptoOperations.keyStore.getPublicKeyById(kid)
             if (publicKey != null) {
-                println("Internal key ${publicKey.kid} attempted")
                 verifyWithKey(cryptoOperations, signatureInput, it, publicKey)
             } else {
                 // use one of the provided public Keys
@@ -216,17 +209,12 @@ class JwsToken private constructor(
                 }
                 when {
                     key != null -> {
-                        println("key ${key.kid} attempted")
                         verifyWithKey(cryptoOperations, signatureInput, it, key)
                     }
                     publicKeys.isNotEmpty() -> {
-                        println("first publickey attempted")
                         verifyWithKey(cryptoOperations, signatureInput, it, publicKeys.first())
                     }
-                    else -> {
-                        println("No keys attempted")
-                        false
-                    }
+                    else -> false
                 }
             }
         }

--- a/sdk/src/main/java/com/microsoft/did/sdk/di/SdkModule.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/di/SdkModule.kt
@@ -23,6 +23,7 @@ import com.microsoft.did.sdk.crypto.plugins.SubtleCryptoScope
 import com.microsoft.did.sdk.datasource.db.SdkDatabase
 import com.microsoft.did.sdk.identifier.registrars.Registrar
 import com.microsoft.did.sdk.identifier.registrars.SidetreeRegistrar
+import com.microsoft.did.sdk.util.log.SdkLog
 import dagger.Module
 import dagger.Provides
 import okhttp3.OkHttpClient
@@ -70,7 +71,7 @@ internal class SdkModule {
     @Provides
     @Singleton
     fun defaultOkHttpClient(): OkHttpClient {
-        val httpLoggingInterceptor = HttpLoggingInterceptor { println(it) }
+        val httpLoggingInterceptor = HttpLoggingInterceptor { SdkLog.d(it) }
         return OkHttpClient()
             .newBuilder()
             .addInterceptor(httpLoggingInterceptor)


### PR DESCRIPTION
Some of them are actually printing keys to the console ... that's more than an issue. I actually noticed that in general our SdkLog statements are very chatty, we should give them an overhaul to see what makes sense.

**Type of change:**
- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [X] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)