### PR TITLE
Add static query for list of VCs

### DIFF
--- a/sdk/src/main/java/com/microsoft/did/sdk/VerifiableCredentialManager.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/VerifiableCredentialManager.kt
@@ -240,8 +240,12 @@ class VerifiableCredentialManager @Inject constructor(
     /**
      * Get all Verifiable Credentials Holders from the database.
      */
-    fun getVerifiableCredentials(): LiveData<List<VerifiableCredentialHolder>> {
+    fun getAllVerifiableCredentials(): LiveData<List<VerifiableCredentialHolder>> {
         return vchRepository.getAllVchs()
+    }
+
+    fun queryAllVerifiableCredentials(): List<VerifiableCredentialHolder> {
+        return vchRepository.queryAllVchs()
     }
 
     /**

--- a/sdk/src/main/java/com/microsoft/did/sdk/datasource/db/dao/VerifiableCredentialHolderDao.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/datasource/db/dao/VerifiableCredentialHolderDao.kt
@@ -18,6 +18,9 @@ interface VerifiableCredentialHolderDao {
     @Query("SELECT * FROM VerifiableCredentialHolder")
     fun getAllVcs(): LiveData<List<VerifiableCredentialHolder>>
 
+    @Query("SELECT * FROM VerifiableCredentialHolder")
+    fun queryAllVcs(): List<VerifiableCredentialHolder>
+
     @Query("SELECT * FROM VerifiableCredentialHolder where picId = :id")
     fun getVcById(id: String): LiveData<VerifiableCredentialHolder>
 

--- a/sdk/src/main/java/com/microsoft/did/sdk/datasource/repository/VerifiableCredentialHolderRepository.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/datasource/repository/VerifiableCredentialHolderRepository.kt
@@ -27,7 +27,6 @@ import com.microsoft.did.sdk.util.Constants.DEFAULT_EXPIRATION_IN_SECONDS
 import com.microsoft.did.sdk.util.controlflow.ExchangeException
 import com.microsoft.did.sdk.util.controlflow.Result
 import com.microsoft.did.sdk.util.serializer.Serializer
-import com.microsoft.did.sdk.util.unwrapSignedVerifiableCredential
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -56,6 +55,8 @@ class VerifiableCredentialHolderRepository @Inject constructor(
     suspend fun delete(verifiableCredentialHolder: VerifiableCredentialHolder) = vchDao.delete(verifiableCredentialHolder)
 
     fun getAllVchs(): LiveData<List<VerifiableCredentialHolder>> = vchDao.getAllVcs()
+
+    fun queryAllVchs(): List<VerifiableCredentialHolder> = vchDao.queryAllVcs()
 
     fun getVchsByType(type: String): LiveData<List<VerifiableCredentialHolder>> {
         return getAllVchs().map { cardList -> filterVcsByType(cardList, type) }


### PR DESCRIPTION
Required to solve our "500ms situation". This call will actually wait for the db to finish the query unlike the LiveData one's


**Type of change:**
- [ ] Feature work
- [X] Bug fix
- [ ] Documentation
- [X] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)