### PR TITLE
Standardize claim formatting and fix bugs

### DIFF
--- a/sdk/src/main/java/com/microsoft/did/sdk/credential/models/VerifiableCredentialHolder.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/credential/models/VerifiableCredentialHolder.kt
@@ -37,9 +37,10 @@ data class VerifiableCredentialHolder(
      * Returns a ordered map containing a mapping of user readable claim label (not localized) to the formatted value.
      * e.g. the value of type date is formatted as a date instead of the raw timestamp.
      *
-     * The order is adhering to the order of the claims within the display contract.
+     * The order is adhering to the order of the claims within the Verifiable Credential.
      *
-     * Claims that are present in the VC but not in the DisplayContract or vice versa will not be contained.
+     * Claims that are present in the VC but not in the DisplayContract are displayed with it's property name prefixed with "? -".
+     * Claims that are present in the DisplayContract but not in the VC are ignored.
      *
      * The display contract does not currently support localized claim labels.
      */
@@ -48,13 +49,11 @@ data class VerifiableCredentialHolder(
         val claimValues = verifiableCredential.contents.vc.credentialSubject
 
         val readableClaimMap = LinkedHashMap<String, String>()
-        for ((claimIdentifier, claimDescriptor) in claimDescriptors) {
-            val truncatedClaimIdentifier = if (claimIdentifier.startsWith("vc.credentialSubject.")) {
-                claimIdentifier.removePrefix("vc.credentialSubject.")
-            } else continue
-            val claimValue = claimValues[truncatedClaimIdentifier] ?: continue
-            val formattedClaimValue = ClaimFormatter.formatClaimValue(claimDescriptor.type, claimValue)
-            readableClaimMap[claimDescriptor.label] = formattedClaimValue
+        for ((claimIdentifier, claimValue) in claimValues) {
+            val claimDescriptor = claimDescriptors["vc.credentialSubject.$claimIdentifier"]
+            val claimLabel = claimDescriptor?.label ?: "? - $claimIdentifier"
+            val formattedClaimValue = ClaimFormatter.formatClaimValue(claimDescriptor?.type ?: "", claimValue)
+            readableClaimMap[claimLabel] = formattedClaimValue
         }
         return readableClaimMap
     }

--- a/sdk/src/main/java/com/microsoft/did/sdk/credential/models/VerifiableCredentialHolder.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/credential/models/VerifiableCredentialHolder.kt
@@ -37,6 +37,10 @@ data class VerifiableCredentialHolder(
      * Returns a ordered map containing a mapping of user readable claim label (not localized) to the formatted value.
      * e.g. the value of type date is formatted as a date instead of the raw timestamp.
      *
+     * The order is adhering to the order of the claims within the display contract.
+     *
+     * Claims that are present in the VC but not in the DisplayContract or vice versa will not be contained.
+     *
      * The display contract does not currently support localized claim labels.
      */
     fun getUserFormattedClaimMap(): LinkedHashMap<String, String> {
@@ -45,8 +49,11 @@ data class VerifiableCredentialHolder(
 
         val readableClaimMap = LinkedHashMap<String, String>()
         for ((claimIdentifier, claimDescriptor) in claimDescriptors) {
-            val truncatedClaimIdentifier = claimIdentifier.split(".").lastOrNull()
-            val formattedClaimValue = ClaimFormatter.formatClaimValue(claimDescriptor.type, claimValues[truncatedClaimIdentifier] ?: continue)
+            val truncatedClaimIdentifier = if (claimIdentifier.startsWith("vc.credentialSubject.")) {
+                claimIdentifier.removePrefix("vc.credentialSubject.")
+            } else continue
+            val claimValue = claimValues[truncatedClaimIdentifier] ?: continue
+            val formattedClaimValue = ClaimFormatter.formatClaimValue(claimDescriptor.type, claimValue)
             readableClaimMap[claimDescriptor.label] = formattedClaimValue
         }
         return readableClaimMap

--- a/sdk/src/main/java/com/microsoft/did/sdk/credential/models/VerifiableCredentialHolder.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/credential/models/VerifiableCredentialHolder.kt
@@ -8,6 +8,7 @@ import androidx.room.PrimaryKey
 import androidx.room.RoomWarnings
 import com.microsoft.did.sdk.credential.service.models.contracts.display.DisplayContract
 import com.microsoft.did.sdk.identifier.models.Identifier
+import com.microsoft.did.sdk.util.ClaimFormatter
 import kotlinx.serialization.Serializable
 
 /**
@@ -30,4 +31,24 @@ data class VerifiableCredentialHolder(
     val owner: Identifier,
 
     val displayContract: DisplayContract
-)
+) {
+
+    /**
+     * Returns a ordered map containing a mapping of user readable claim label (not localized) to the formatted value.
+     * e.g. the value of type date is formatted as a date instead of the raw timestamp.
+     *
+     * The display contract does not currently support localized claim labels.
+     */
+    fun getUserFormattedClaimMap(): LinkedHashMap<String, String> {
+        val claimDescriptors = displayContract.claims
+        val claimValues = verifiableCredential.contents.vc.credentialSubject
+
+        val readableClaimMap = LinkedHashMap<String, String>()
+        for ((claimIdentifier, claimDescriptor) in claimDescriptors) {
+            val truncatedClaimIdentifier = claimIdentifier.split(".").lastOrNull()
+            val formattedClaimValue = ClaimFormatter.formatClaimValue(claimDescriptor.type, claimValues[truncatedClaimIdentifier] ?: continue)
+            readableClaimMap[claimDescriptor.label] = formattedClaimValue
+        }
+        return readableClaimMap
+    }
+}

--- a/sdk/src/main/java/com/microsoft/did/sdk/credential/service/models/contracts/display/ClaimDescriptor.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/credential/service/models/contracts/display/ClaimDescriptor.kt
@@ -14,10 +14,10 @@ import kotlinx.serialization.Serializable
 data class ClaimDescriptor(
 
     // What data type the claim is (ex. "Date")
-    val type: String? = null,
+    val type: String,
 
     // A label used to describe the claim (ex. "Birthday").
-    val label: String? = null,
+    val label: String,
 
     // Used to describe to claim if claim is an image for alt text or voice over.
     val description: String? = null

--- a/sdk/src/main/java/com/microsoft/did/sdk/util/ClaimFormatter.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/util/ClaimFormatter.kt
@@ -6,18 +6,26 @@
 package com.microsoft.did.sdk.util
 
 import java.text.DateFormat
-import java.util.Locale
 
 object ClaimFormatter {
 
+    enum class ClaimType {
+        DATE,
+        TEXT
+    }
+
     fun formatClaimValue(type: String, claimValue: String): String {
-        return when(type.toLowerCase(Locale.ENGLISH)) {
-            "date" -> formatDate(claimValue.toLong())
-            else -> claimValue
+        return when (type.asEnumOrDefault(ClaimType.TEXT)) {
+            ClaimType.DATE -> formatDate(claimValue.toLongOrNull())
+            ClaimType.TEXT -> claimValue
         }
     }
 
-    fun formatDate(timestamp: Long): String {
+    fun formatDate(timestamp: Long?): String {
+        if (timestamp == null) return "?"
         return DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.MEDIUM).format(timestamp)
     }
 }
+
+inline fun <reified T : Enum<T>> String.asEnumOrDefault(defaultValue: T): T =
+    enumValues<T>().firstOrNull { it.name.equals(this, ignoreCase = true) } ?: defaultValue

--- a/sdk/src/main/java/com/microsoft/did/sdk/util/ClaimFormatter.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/util/ClaimFormatter.kt
@@ -1,0 +1,23 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+package com.microsoft.did.sdk.util
+
+import java.text.DateFormat
+import java.util.Locale
+
+object ClaimFormatter {
+
+    fun formatClaimValue(type: String, claimValue: String): String {
+        return when(type.toLowerCase(Locale.ENGLISH)) {
+            "date" -> formatDate(claimValue.toLong())
+            else -> claimValue
+        }
+    }
+
+    fun formatDate(timestamp: Long): String {
+        return DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.MEDIUM).format(timestamp)
+    }
+}

--- a/sdk/src/test/java/com/microsoft/did/sdk/credential/models/VerifiableCredentialHolderTest.kt
+++ b/sdk/src/test/java/com/microsoft/did/sdk/credential/models/VerifiableCredentialHolderTest.kt
@@ -15,7 +15,7 @@ import org.junit.Test
 class VerifiableCredentialHolderTest {
 
     private val claimDescriptor1 = ClaimDescriptor(ClaimFormatter.ClaimType.TEXT.name, "name 1", null)
-    private val claimDescriptor2 = ClaimDescriptor(ClaimFormatter.ClaimType.TEXT.name, "name 2", null)
+    private val claimDescriptor2 = ClaimDescriptor(ClaimFormatter.ClaimType.DATE.name, "name 2", null)
     private val claimDescriptor3 = ClaimDescriptor(ClaimFormatter.ClaimType.DATE.name, "name 3", null)
     private val claimDescriptor4 = ClaimDescriptor(ClaimFormatter.ClaimType.DATE.name, "not matching name", null)
     private val vc: VerifiableCredential = mockk()
@@ -38,7 +38,7 @@ class VerifiableCredentialHolderTest {
             "not matching claim" to "value 4"
         )
         val expectedResult = mapOf(
-            "name 2" to "value2",
+            "name 2" to "?",
             "name 1" to "value1",
             "name 3" to ClaimFormatter.formatDate(1588655105000)
         )

--- a/sdk/src/test/java/com/microsoft/did/sdk/credential/models/VerifiableCredentialHolderTest.kt
+++ b/sdk/src/test/java/com/microsoft/did/sdk/credential/models/VerifiableCredentialHolderTest.kt
@@ -14,10 +14,10 @@ import org.junit.Test
 
 class VerifiableCredentialHolderTest {
 
-    private val claimDescriptor1 = ClaimDescriptor("text", "name 1", null)
-    private val claimDescriptor2 = ClaimDescriptor("text", "name 2", null)
-    private val claimDescriptor3 = ClaimDescriptor("date", "name 3", null)
-    private val claimDescriptor4 = ClaimDescriptor("date", "not matching name", null)
+    private val claimDescriptor1 = ClaimDescriptor(ClaimFormatter.ClaimType.TEXT.name, "name 1", null)
+    private val claimDescriptor2 = ClaimDescriptor(ClaimFormatter.ClaimType.TEXT.name, "name 2", null)
+    private val claimDescriptor3 = ClaimDescriptor(ClaimFormatter.ClaimType.DATE.name, "name 3", null)
+    private val claimDescriptor4 = ClaimDescriptor(ClaimFormatter.ClaimType.DATE.name, "not matching name", null)
     private val vc: VerifiableCredential = mockk()
     private val displayContract: DisplayContract = mockk()
     private val vch: VerifiableCredentialHolder = spyk(VerifiableCredentialHolder("", vc, mockk(), displayContract))

--- a/sdk/src/test/java/com/microsoft/did/sdk/credential/models/VerifiableCredentialHolderTest.kt
+++ b/sdk/src/test/java/com/microsoft/did/sdk/credential/models/VerifiableCredentialHolderTest.kt
@@ -25,22 +25,23 @@ class VerifiableCredentialHolderTest {
     @Test
     fun `map is matched, sorted and formatted properly`() {
         every { displayContract.claims } returns mapOf(
-            "vc.credentialSubject.claim2" to claimDescriptor2,
             "vc.credentialSubject.claim1" to claimDescriptor1,
+            "vc.credentialSubject.claim2" to claimDescriptor2,
             "vc.credentialSubject.claim3" to claimDescriptor3,
             "claim2" to claimDescriptor4,
             "no matching claim" to claimDescriptor4
         )
         every { vc.contents.vc.credentialSubject } returns mapOf(
-            "claim1" to "value1",
             "claim2" to "value2",
+            "claim1" to "value1",
             "claim3" to "1588655105000",
-            "not matching claim" to "value 4"
+            "noMatchingDisplayContract" to "value 4"
         )
         val expectedResult = mapOf(
             "name 2" to "?",
             "name 1" to "value1",
-            "name 3" to ClaimFormatter.formatDate(1588655105000)
+            "name 3" to ClaimFormatter.formatDate(1588655105000),
+            "? - noMatchingDisplayContract" to "value 4"
         )
         val actualResult = vch.getUserFormattedClaimMap()
         assertThat(actualResult).isEqualTo(expectedResult)

--- a/sdk/src/test/java/com/microsoft/did/sdk/credential/models/VerifiableCredentialHolderTest.kt
+++ b/sdk/src/test/java/com/microsoft/did/sdk/credential/models/VerifiableCredentialHolderTest.kt
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation. All rights reserved
+
+package com.microsoft.did.sdk.credential.models
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.microsoft.did.sdk.credential.service.models.contracts.display.ClaimDescriptor
+import com.microsoft.did.sdk.credential.service.models.contracts.display.DisplayContract
+import com.microsoft.did.sdk.util.ClaimFormatter
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import org.junit.Test
+
+class VerifiableCredentialHolderTest {
+
+    private val claimDescriptor1 = ClaimDescriptor("text", "name 1", null)
+    private val claimDescriptor2 = ClaimDescriptor("text", "name 2", null)
+    private val claimDescriptor3 = ClaimDescriptor("date", "name 3", null)
+    private val claimDescriptor4 = ClaimDescriptor("date", "not matching name", null)
+    private val vc: VerifiableCredential = mockk()
+    private val displayContract: DisplayContract = mockk()
+    private val vch: VerifiableCredentialHolder = spyk(VerifiableCredentialHolder("", vc, mockk(), displayContract))
+
+    @Test
+    fun `map is matched, sorted and formatted properly`() {
+        every { displayContract.claims } returns mapOf(
+            "vc.credentialSubject.claim2" to claimDescriptor2,
+            "vc.credentialSubject.claim1" to claimDescriptor1,
+            "vc.credentialSubject.claim3" to claimDescriptor3,
+            "claim2" to claimDescriptor4,
+            "no matching claim" to claimDescriptor4
+        )
+        every { vc.contents.vc.credentialSubject } returns mapOf(
+            "claim1" to "value1",
+            "claim2" to "value2",
+            "claim3" to "1588655105000",
+            "not matching claim" to "value 4"
+        )
+        val expectedResult = mapOf(
+            "name 2" to "value2",
+            "name 1" to "value1",
+            "name 3" to ClaimFormatter.formatDate(1588655105000)
+        )
+        val actualResult = vch.getUserFormattedClaimMap()
+        assertThat(actualResult).isEqualTo(expectedResult)
+    }
+}


### PR DESCRIPTION
Added functionality to vch to match up the proper values with each other. We need this functionality in multiple places and don't want to reimplement. Also added more precise rules and fixed bugs that are documented in the method comment. 

**Type of change:**
- [X] Feature work
- [X] Bug fix
- [ ] Documentation
- [X] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)