### PR TITLE
Add scope value to idtoken attestations

### DIFF
--- a/sdk/src/main/java/com/microsoft/did/sdk/credential/service/models/attestations/IdTokenAttestation.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/credential/service/models/attestations/IdTokenAttestation.kt
@@ -18,7 +18,7 @@ data class IdTokenAttestation(
 
     val client_id: String,
 
-    val redirect_uri: String,
+    val redirect_uri: String = "",
 
-    val scope: String
+    val scope: String = "openid"
 )

--- a/sdk/src/main/java/com/microsoft/did/sdk/credential/service/models/attestations/IdTokenAttestation.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/credential/service/models/attestations/IdTokenAttestation.kt
@@ -18,5 +18,7 @@ data class IdTokenAttestation(
 
     val client_id: String,
 
-    val redirect_uri: String
+    val redirect_uri: String,
+
+    val scope: String
 )


### PR DESCRIPTION
The scope is sent to the idp to define what is supposed to be contained in the idtoken


**Type of change:**
- [X] Feature work
- [ ] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)
