### PR TITLE
Replace retrofit serializer from Gson to Kotlin serializtion + Log ms-cv for Networkcalls

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -85,9 +85,9 @@ dependencies {
     kapt "com.google.dagger:dagger-compiler:$dagger_version"
 
     implementation "com.squareup.retrofit2:retrofit:$retrofit2_version"
-    implementation "com.squareup.retrofit2:converter-gson:$retrofit2_version"
     implementation "com.squareup.retrofit2:converter-scalars:$retrofit2_version"
     implementation "com.jakewharton.retrofit:retrofit2-kotlin-coroutines-adapter:0.9.2"
+    implementation "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:0.5.0"
 
     implementation "androidx.room:room-runtime:$androidx_room_persistence_version"
     implementation "androidx.room:room-ktx:$androidx_room_persistence_version"

--- a/sdk/src/main/java/com/microsoft/did/sdk/datasource/network/BaseNetworkOperation.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/datasource/network/BaseNetworkOperation.kt
@@ -50,7 +50,13 @@ abstract class BaseNetworkOperation<S, T> {
         val requestId = response.headers()["request-id"] ?: "?"
         val correlationVector = response.headers()["ms-cv"] ?: "?"
         return when (response.code()) {
-            401 -> Result.Failure(UnauthorizedException(requestId, "${response.code()}: ${response.errorBody()?.string()}", false))
+            401 -> Result.Failure(
+                UnauthorizedException(
+                    requestId,
+                    defaultErrorMessage(response.code(), requestId, correlationVector, response.errorBody()?.string() ?: ""),
+                    false
+                )
+            )
             402, 403, 404 -> Result.Failure(
                 ServiceErrorException(
                     requestId,

--- a/sdk/src/main/java/com/microsoft/did/sdk/datasource/network/credentialOperations/FetchContractNetworkOperation.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/datasource/network/credentialOperations/FetchContractNetworkOperation.kt
@@ -18,7 +18,6 @@ class FetchContractNetworkOperation(val url: String, apiProvider: ApiProvider) :
 
     override fun onSuccess(response: Response<VerifiableCredentialContract>): Result<VerifiableCredentialContract> {
         val contract = response.body() ?: throw IssuanceException("Contract was not found in response")
-        contract.input.attestations.idTokens.map { claim -> claim.claims.map { type -> if (type.type == null) type.type = "" } }
         return Result.Success(contract)
     }
 }

--- a/sdk/src/main/java/com/microsoft/did/sdk/di/SdkModule.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/di/SdkModule.kt
@@ -8,6 +8,7 @@ package com.microsoft.did.sdk.di
 import android.content.Context
 import androidx.room.Room
 import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.microsoft.did.sdk.credential.service.validators.OidcPresentationRequestValidator
 import com.microsoft.did.sdk.credential.service.validators.PresentationRequestValidator
 import com.microsoft.did.sdk.crypto.CryptoOperations
@@ -24,12 +25,14 @@ import com.microsoft.did.sdk.datasource.db.SdkDatabase
 import com.microsoft.did.sdk.identifier.registrars.Registrar
 import com.microsoft.did.sdk.identifier.registrars.SidetreeRegistrar
 import com.microsoft.did.sdk.util.log.SdkLog
+import com.microsoft.did.sdk.util.serializer.Serializer
 import dagger.Module
 import dagger.Provides
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
-import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.converter.scalars.ScalarsConverterFactory
 import javax.inject.Singleton
 
@@ -80,12 +83,13 @@ internal class SdkModule {
 
     @Provides
     @Singleton
-    fun defaultRetrofit(okHttpClient: OkHttpClient): Retrofit {
+    fun defaultRetrofit(okHttpClient: OkHttpClient, serializer: Serializer): Retrofit {
+        val contentType = MediaType.get("application/json")
         return Retrofit.Builder()
             .baseUrl("http://TODO.me")
             .client(okHttpClient)
             .addConverterFactory(ScalarsConverterFactory.create())
-            .addConverterFactory(GsonConverterFactory.create())
+            .addConverterFactory(serializer.json.asConverterFactory(contentType))
             .addCallAdapterFactory(CoroutineCallAdapterFactory())
             .build()
     }

--- a/sdk/src/main/java/com/microsoft/did/sdk/identifier/models/identifierdocument/IdentifierMetadata.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/identifier/models/identifierdocument/IdentifierMetadata.kt
@@ -9,6 +9,6 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class IdentifierMetadata(
     @SerialName("operationPublicKeys")
-    val operationPublicKeys: List<IdentifierDocumentPublicKey>,
-    val recoveryKey: JsonWebKey
+    val operationPublicKeys: List<IdentifierDocumentPublicKey>? = null,
+    val recoveryKey: JsonWebKey? = null
 )


### PR DESCRIPTION
Gson does not understand Kotlin default values, therefore they are ignored and commonly cause bugs when non-nullable fields are null.

Respecting the default value was also required for idtoken scope and more places that we have ignored thus far.

**Type of change:**
- [X] Feature work
- [X] Bug fix
- [ ] Documentation
- [X] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [X] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)