### PR TITLE
Warn instead of fail if well known config document is not uploaded.

### DIFF
--- a/sdk/src/main/java/com/microsoft/did/sdk/CorrelationVectorService.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/CorrelationVectorService.kt
@@ -5,8 +5,7 @@
 
 package com.microsoft.did.sdk
 
-import android.content.Context
-import androidx.preference.PreferenceManager
+import android.content.SharedPreferences
 import com.microsoft.correlationvector.CorrelationVector
 import com.microsoft.correlationvector.CorrelationVectorVersion
 import com.microsoft.did.sdk.util.Constants
@@ -14,31 +13,31 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class CorrelationVectorService @Inject constructor(private val context: Context) {
+class CorrelationVectorService @Inject constructor(private val sharedPreferences: SharedPreferences) {
 
     fun startNewFlowAndSave(): String {
         val correlationId = CorrelationVector(CorrelationVectorVersion.V2).value
-        saveCorrelationVector(context, correlationId)
+        saveCorrelationVector(sharedPreferences, correlationId)
         return correlationId
     }
 
     internal fun incrementAndSave(): String {
-        val correlationVectorString = getCorrelationVector(context)
+        val correlationVectorString = getCorrelationVector(sharedPreferences)
         if (correlationVectorString != null && correlationVectorString.isNotEmpty()) {
             val correlationVectorIncremented = CorrelationVector.parse(correlationVectorString).increment()
-            saveCorrelationVector(context, correlationVectorIncremented)
+            saveCorrelationVector(sharedPreferences, correlationVectorIncremented)
             return correlationVectorIncremented
         }
         return ""
     }
 
-    fun getCorrelationVector(applicationContext: Context = context): String? {
-        return PreferenceManager.getDefaultSharedPreferences(applicationContext).getString(Constants.CORRELATION_VECTOR_IN_PREF, null)
+    fun getCorrelationVector(sharedPreference: SharedPreferences = sharedPreferences): String? {
+        return sharedPreference.getString(Constants.CORRELATION_VECTOR_IN_PREF, null)
     }
 
-    private fun saveCorrelationVector(applicationContext: Context, correlationId: String) {
+    private fun saveCorrelationVector(sharedPreferences: SharedPreferences, correlationId: String) {
         if (correlationId.isNotEmpty())
-            PreferenceManager.getDefaultSharedPreferences(applicationContext).edit()
+            sharedPreferences.edit()
                 .putString(Constants.CORRELATION_VECTOR_IN_PREF, correlationId).apply()
     }
 }

--- a/sdk/src/main/java/com/microsoft/did/sdk/FeatureFlag.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/FeatureFlag.kt
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved
+
+package com.microsoft.did.sdk
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class FeatureFlag @Inject constructor() {
+    var linkedDomains: Boolean = false
+}

--- a/sdk/src/main/java/com/microsoft/did/sdk/IssuanceService.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/IssuanceService.kt
@@ -9,6 +9,7 @@ import com.microsoft.did.sdk.credential.models.VerifiableCredential
 import com.microsoft.did.sdk.credential.service.IssuanceRequest
 import com.microsoft.did.sdk.credential.service.IssuanceResponse
 import com.microsoft.did.sdk.credential.service.RequestedVcMap
+import com.microsoft.did.sdk.credential.service.models.linkedDomains.LinkedDomainDisabled
 import com.microsoft.did.sdk.credential.service.protectors.IssuanceResponseFormatter
 import com.microsoft.did.sdk.credential.service.validators.JwtValidator
 import com.microsoft.did.sdk.datasource.network.apis.ApiProvider
@@ -38,11 +39,12 @@ class IssuanceService @Inject constructor(
      *
      * @param contractUrl url that the contract is fetched from
      */
-    suspend fun getRequest(contractUrl: String, isLinkedDomainsEnabled: Boolean): Result<IssuanceRequest> {
+    suspend fun getRequest(contractUrl: String): Result<IssuanceRequest> {
         return runResultTry {
             val contract = fetchContract(contractUrl).abortOnError()
+            val isLinkedDomainsEnabled = VerifiableCredentialSdk.FeatureFlag.linkedDomains
             val linkedDomainResult =
-                if (isLinkedDomainsEnabled) linkedDomainsService.fetchAndVerifyLinkedDomains(contract.input.issuer).abortOnError() else null
+                if (isLinkedDomainsEnabled) linkedDomainsService.fetchAndVerifyLinkedDomains(contract.input.issuer).abortOnError() else LinkedDomainDisabled()
             val request = IssuanceRequest(contract, contractUrl, linkedDomainResult)
             Result.Success(request)
         }

--- a/sdk/src/main/java/com/microsoft/did/sdk/IssuanceService.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/IssuanceService.kt
@@ -31,7 +31,8 @@ class IssuanceService @Inject constructor(
     private val apiProvider: ApiProvider,
     private val jwtValidator: JwtValidator,
     private val issuanceResponseFormatter: IssuanceResponseFormatter,
-    private val serializer: Json
+    private val serializer: Json,
+    private val featureFlag: FeatureFlag
 ) {
 
     /**
@@ -42,7 +43,7 @@ class IssuanceService @Inject constructor(
     suspend fun getRequest(contractUrl: String): Result<IssuanceRequest> {
         return runResultTry {
             val contract = fetchContract(contractUrl).abortOnError()
-            val isLinkedDomainsEnabled = VerifiableCredentialSdk.FeatureFlag.linkedDomains
+            val isLinkedDomainsEnabled = featureFlag.linkedDomains
             val linkedDomainResult =
                 if (isLinkedDomainsEnabled) linkedDomainsService.fetchAndVerifyLinkedDomains(contract.input.issuer).abortOnError() else LinkedDomainDisabled()
             val request = IssuanceRequest(contract, contractUrl, linkedDomainResult)

--- a/sdk/src/main/java/com/microsoft/did/sdk/IssuanceService.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/IssuanceService.kt
@@ -38,10 +38,11 @@ class IssuanceService @Inject constructor(
      *
      * @param contractUrl url that the contract is fetched from
      */
-    suspend fun getRequest(contractUrl: String): Result<IssuanceRequest> {
+    suspend fun getRequest(contractUrl: String, isLinkedDomainsEnabled: Boolean): Result<IssuanceRequest> {
         return runResultTry {
             val contract = fetchContract(contractUrl).abortOnError()
-            val linkedDomainResult = linkedDomainsService.fetchAndVerifyLinkedDomains(contract.input.issuer).abortOnError()
+            val linkedDomainResult =
+                if (isLinkedDomainsEnabled) linkedDomainsService.fetchAndVerifyLinkedDomains(contract.input.issuer).abortOnError() else null
             val request = IssuanceRequest(contract, contractUrl, linkedDomainResult)
             Result.Success(request)
         }

--- a/sdk/src/main/java/com/microsoft/did/sdk/LinkedDomainsService.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/LinkedDomainsService.kt
@@ -14,6 +14,7 @@ import com.microsoft.did.sdk.util.Constants
 import com.microsoft.did.sdk.util.controlflow.Result
 import com.microsoft.did.sdk.util.controlflow.map
 import com.microsoft.did.sdk.util.controlflow.runResultTry
+import com.microsoft.did.sdk.util.log.SdkLog
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -35,11 +36,14 @@ class LinkedDomainsService @Inject constructor(
             if (domainUrls.isEmpty())
                 return@runResultTry Result.Success(LinkedDomainMissing())
             val domainUrl = domainUrls.first()
-            val wellKnownConfigDocument = getWellKnownConfigDocument(domainUrl).abortOnError()
-            wellKnownConfigDocument.linkedDids.forEach { linkedDidJwt ->
-                val isDomainLinked = jwtDomainLinkageCredentialValidator.validate(linkedDidJwt, relyingPartyDid, domainUrl)
-                if (isDomainLinked) return@runResultTry Result.Success(LinkedDomainVerified(domainUrl))
-            }
+            val wellKnownConfigDocumentResult = getWellKnownConfigDocument(domainUrl)
+            if (wellKnownConfigDocumentResult is Result.Success) {
+                val wellKnownConfigDocument = wellKnownConfigDocumentResult.payload
+                wellKnownConfigDocument.linkedDids.forEach { linkedDidJwt ->
+                    val isDomainLinked = jwtDomainLinkageCredentialValidator.validate(linkedDidJwt, relyingPartyDid, domainUrl)
+                    if (isDomainLinked) return@runResultTry Result.Success(LinkedDomainVerified(domainUrl))
+                }
+            } else SdkLog.d("Unable to fetch well-known config document from $domainUrl")
             Result.Success(LinkedDomainUnVerified(domainUrl))
         }
     }

--- a/sdk/src/main/java/com/microsoft/did/sdk/PresentationService.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/PresentationService.kt
@@ -35,11 +35,13 @@ class PresentationService @Inject constructor(
     private val apiProvider: ApiProvider,
     private val presentationResponseFormatter: PresentationResponseFormatter
 ) {
-    suspend fun getRequest(stringUri: String): Result<PresentationRequest> {
+    suspend fun getRequest(stringUri: String, isLinkedDomainsEnabled: Boolean): Result<PresentationRequest> {
         return runResultTry {
             val uri = verifyUri(stringUri)
             val presentationRequestContent = getPresentationRequestContent(uri).abortOnError()
-            val linkedDomainResult = linkedDomainsService.fetchAndVerifyLinkedDomains(presentationRequestContent.issuer).abortOnError()
+            val linkedDomainResult =
+                if (isLinkedDomainsEnabled) linkedDomainsService.fetchAndVerifyLinkedDomains(presentationRequestContent.issuer)
+                    .abortOnError() else null
             val request = PresentationRequest(presentationRequestContent, linkedDomainResult)
             isRequestValid(request).abortOnError()
             Result.Success(request)

--- a/sdk/src/main/java/com/microsoft/did/sdk/PresentationService.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/PresentationService.kt
@@ -34,13 +34,14 @@ class PresentationService @Inject constructor(
     private val jwtValidator: JwtValidator,
     private val presentationRequestValidator: PresentationRequestValidator,
     private val apiProvider: ApiProvider,
-    private val presentationResponseFormatter: PresentationResponseFormatter
+    private val presentationResponseFormatter: PresentationResponseFormatter,
+    private val featureFlag: FeatureFlag
 ) {
     suspend fun getRequest(stringUri: String): Result<PresentationRequest> {
         return runResultTry {
             val uri = verifyUri(stringUri)
             val presentationRequestContent = getPresentationRequestContent(uri).abortOnError()
-            val isLinkedDomainsEnabled = VerifiableCredentialSdk.FeatureFlag.linkedDomains
+            val isLinkedDomainsEnabled = featureFlag.linkedDomains
             val linkedDomainResult =
                 if (isLinkedDomainsEnabled) linkedDomainsService.fetchAndVerifyLinkedDomains(presentationRequestContent.issuer)
                     .abortOnError() else LinkedDomainDisabled()

--- a/sdk/src/main/java/com/microsoft/did/sdk/VerifiableCredentialSdk.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/VerifiableCredentialSdk.kt
@@ -27,10 +27,6 @@ import com.microsoft.did.sdk.util.log.SdkLog
  */
 object VerifiableCredentialSdk {
 
-    object FeatureFlag {
-        var linkedDomains: Boolean = false
-    }
-
     @JvmStatic
     lateinit var issuanceService: IssuanceService
 
@@ -46,7 +42,8 @@ object VerifiableCredentialSdk {
     @JvmStatic
     internal lateinit var identifierManager: IdentifierManager
 
-//    lateinit var featureFlag: FeatureFlag
+    @JvmStatic
+    lateinit var featureFlag: FeatureFlag
 
     /**
      * Initializes VerifiableCredentialSdk
@@ -80,7 +77,7 @@ object VerifiableCredentialSdk {
         identifierManager = sdkComponent.identifierManager()
 
         correlationVectorService.startNewFlowAndSave()
-//        featureFlag = FeatureFlag()
+        featureFlag = sdkComponent.featureFlag()
 
         SdkLog.addConsumer(logConsumer)
     }

--- a/sdk/src/main/java/com/microsoft/did/sdk/VerifiableCredentialSdk.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/VerifiableCredentialSdk.kt
@@ -5,7 +5,6 @@
 
 package com.microsoft.did.sdk
 
-import android.annotation.SuppressLint
 import android.content.Context
 import com.microsoft.did.sdk.di.DaggerSdkComponent
 import com.microsoft.did.sdk.util.log.DefaultLogConsumer
@@ -28,6 +27,10 @@ import com.microsoft.did.sdk.util.log.SdkLog
  */
 object VerifiableCredentialSdk {
 
+    object FeatureFlag {
+        var linkedDomains: Boolean = false
+    }
+
     @JvmStatic
     lateinit var issuanceService: IssuanceService
 
@@ -37,12 +40,13 @@ object VerifiableCredentialSdk {
     @JvmStatic
     lateinit var revocationService: RevocationService
 
-    @SuppressLint("StaticFieldLeak")
     @JvmStatic
     lateinit var correlationVectorService: CorrelationVectorService
 
     @JvmStatic
     internal lateinit var identifierManager: IdentifierManager
+
+//    lateinit var featureFlag: FeatureFlag
 
     /**
      * Initializes VerifiableCredentialSdk
@@ -76,6 +80,7 @@ object VerifiableCredentialSdk {
         identifierManager = sdkComponent.identifierManager()
 
         correlationVectorService.startNewFlowAndSave()
+//        featureFlag = FeatureFlag()
 
         SdkLog.addConsumer(logConsumer)
     }

--- a/sdk/src/main/java/com/microsoft/did/sdk/credential/service/Request.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/credential/service/Request.kt
@@ -13,13 +13,13 @@ import com.microsoft.did.sdk.credential.service.models.presentationexchange.Pres
 import kotlinx.serialization.Serializable
 
 @Serializable
-sealed class Request(val entityName: String, val entityIdentifier: String, val entityLinkedDomainResult: LinkedDomainResult? = null)
+sealed class Request(val entityName: String, val entityIdentifier: String, val entityLinkedDomainResult: LinkedDomainResult)
 
 @Serializable
 class IssuanceRequest(
     val contract: VerifiableCredentialContract,
     val contractUrl: String,
-    val linkedDomainResult: LinkedDomainResult? = null
+    val linkedDomainResult: LinkedDomainResult
 ) : Request(contract.display.card.issuedBy, contract.input.issuer, linkedDomainResult) {
     fun getAttestations(): CredentialAttestations {
         return contract.input.attestations
@@ -29,7 +29,7 @@ class IssuanceRequest(
 @Serializable
 class PresentationRequest(
     val content: PresentationRequestContent,
-    val linkedDomainResult: LinkedDomainResult? = null
+    val linkedDomainResult: LinkedDomainResult
 ) : Request(content.registration.clientName, content.issuer, linkedDomainResult) {
     fun getPresentationDefinition(): PresentationDefinition {
         return content.presentationDefinition

--- a/sdk/src/main/java/com/microsoft/did/sdk/credential/service/Request.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/credential/service/Request.kt
@@ -13,13 +13,13 @@ import com.microsoft.did.sdk.credential.service.models.presentationexchange.Pres
 import kotlinx.serialization.Serializable
 
 @Serializable
-sealed class Request(val entityName: String, val entityIdentifier: String, val entityLinkedDomainResult: LinkedDomainResult)
+sealed class Request(val entityName: String, val entityIdentifier: String, val entityLinkedDomainResult: LinkedDomainResult? = null)
 
 @Serializable
 class IssuanceRequest(
     val contract: VerifiableCredentialContract,
     val contractUrl: String,
-    val linkedDomainResult: LinkedDomainResult
+    val linkedDomainResult: LinkedDomainResult? = null
 ) : Request(contract.display.card.issuedBy, contract.input.issuer, linkedDomainResult) {
     fun getAttestations(): CredentialAttestations {
         return contract.input.attestations
@@ -29,7 +29,7 @@ class IssuanceRequest(
 @Serializable
 class PresentationRequest(
     val content: PresentationRequestContent,
-    val linkedDomainResult: LinkedDomainResult
+    val linkedDomainResult: LinkedDomainResult? = null
 ) : Request(content.registration.clientName, content.issuer, linkedDomainResult) {
     fun getPresentationDefinition(): PresentationDefinition {
         return content.presentationDefinition

--- a/sdk/src/main/java/com/microsoft/did/sdk/credential/service/models/linkedDomains/LinkedDomainResult.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/credential/service/models/linkedDomains/LinkedDomainResult.kt
@@ -15,3 +15,6 @@ class LinkedDomainUnVerified(val domainUrl: String) : LinkedDomainResult()
 
 @Serializable
 class LinkedDomainMissing : LinkedDomainResult()
+
+@Serializable
+class LinkedDomainDisabled : LinkedDomainResult()

--- a/sdk/src/main/java/com/microsoft/did/sdk/datasource/network/linkedDomainsOperations/FetchWellKnownConfigDocumentNetworkOperation.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/datasource/network/linkedDomainsOperations/FetchWellKnownConfigDocumentNetworkOperation.kt
@@ -9,8 +9,6 @@ import com.microsoft.did.sdk.credential.service.models.serviceResponses.LinkedDo
 import com.microsoft.did.sdk.datasource.network.GetNetworkOperation
 import com.microsoft.did.sdk.datasource.network.apis.ApiProvider
 import com.microsoft.did.sdk.util.Constants
-import com.microsoft.did.sdk.util.controlflow.Result
-import com.microsoft.did.sdk.util.controlflow.UnableToFetchWellKnownConfigDocument
 import retrofit2.Response
 import javax.inject.Inject
 
@@ -19,8 +17,4 @@ class FetchWellKnownConfigDocumentNetworkOperation @Inject constructor(val url: 
 
     override val call: suspend () -> Response<LinkedDomainsResponse> =
         { apiProvider.linkedDomainsApis.fetchWellKnownConfigDocument("$url/${Constants.WELL_KNOWN_CONFIG_DOCUMENT_LOCATION}") }
-
-    override fun onFailure(response: Response<LinkedDomainsResponse>): Result<Nothing> {
-        return Result.Failure(UnableToFetchWellKnownConfigDocument("Unable to fetch well-known config document from $url"))
-    }
 }

--- a/sdk/src/main/java/com/microsoft/did/sdk/di/SdkComponent.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/di/SdkComponent.kt
@@ -7,6 +7,7 @@ package com.microsoft.did.sdk.di
 
 import android.content.Context
 import com.microsoft.did.sdk.CorrelationVectorService
+import com.microsoft.did.sdk.FeatureFlag
 import com.microsoft.did.sdk.LinkedDomainsService
 import com.microsoft.did.sdk.IdentifierManager
 import com.microsoft.did.sdk.IssuanceService
@@ -40,6 +41,8 @@ internal interface SdkComponent {
     fun linkedDomainsService(): LinkedDomainsService
     
     fun correlationVectorService(): CorrelationVectorService
+
+    fun featureFlag() : FeatureFlag
 
     @Component.Builder
     interface Builder {

--- a/sdk/src/main/java/com/microsoft/did/sdk/di/SdkModule.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/di/SdkModule.kt
@@ -6,6 +6,8 @@
 package com.microsoft.did.sdk.di
 
 import android.content.Context
+import android.content.SharedPreferences
+import androidx.preference.PreferenceManager
 import androidx.room.Room
 import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
@@ -146,5 +148,11 @@ class SdkModule {
             ignoreUnknownKeys = true
             isLenient = true
         }
+    }
+
+    @Provides
+    @Singleton
+    fun defaultSharedPreferences(context: Context): SharedPreferences {
+        return PreferenceManager.getDefaultSharedPreferences(context)
     }
 }

--- a/sdk/src/test/java/com/microsoft/did/sdk/IssuanceServiceTest.kt
+++ b/sdk/src/test/java/com/microsoft/did/sdk/IssuanceServiceTest.kt
@@ -126,7 +126,7 @@ class IssuanceServiceTest {
         every { mockedIdentifierDocumentService.serviceEndpoint } returns listOf(mockedIdentifierDocumentServiceEndpoint)
 
         runBlocking {
-            val actualRequest = issuanceService.getRequest(suppliedContractUrl)
+            val actualRequest = issuanceService.getRequest(suppliedContractUrl, true)
             assertThat(actualRequest).isInstanceOf(Result.Success::class.java)
             assertThat((actualRequest as Result.Success).payload.contractUrl).isEqualTo(suppliedContractUrl)
             assertThat(actualRequest.payload.linkedDomainResult).isInstanceOf(LinkedDomainVerified::class.java)

--- a/sdk/src/test/java/com/microsoft/did/sdk/IssuanceServiceTest.kt
+++ b/sdk/src/test/java/com/microsoft/did/sdk/IssuanceServiceTest.kt
@@ -126,7 +126,7 @@ class IssuanceServiceTest {
         every { mockedIdentifierDocumentService.serviceEndpoint } returns listOf(mockedIdentifierDocumentServiceEndpoint)
 
         runBlocking {
-            val actualRequest = issuanceService.getRequest(suppliedContractUrl, true)
+            val actualRequest = issuanceService.getRequest(suppliedContractUrl)
             assertThat(actualRequest).isInstanceOf(Result.Success::class.java)
             assertThat((actualRequest as Result.Success).payload.contractUrl).isEqualTo(suppliedContractUrl)
             assertThat(actualRequest.payload.linkedDomainResult).isInstanceOf(LinkedDomainVerified::class.java)


### PR DESCRIPTION
If domain is bound to DID but config document is not uploaded, consider it a warning case instead of failure. 


**Solution:**
Changed the result returned as warning instead of failure. Also completely bypass linked domain verification if feature flag is turned off.
As part of this, made the following changes.
- Created a class for feature flags
- Replaced injecting the context with only shared preference as it is sufficient


**Validation:**
Manually verified success and failure scenarios.
Verified if all the tests successfully passed.


**Type of change:**
- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.