### PR TITLE
Added remaining OIDC validation and changed response to be sent to client_id in the request.

### DIFF
--- a/sdk/src/main/java/com/microsoft/did/sdk/credential/service/Response.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/credential/service/Response.kt
@@ -25,7 +25,7 @@ class IssuanceResponse(override val request: IssuanceRequest) :
 }
 
 class PresentationResponse(override val request: PresentationRequest) :
-    Response(request, request.content.redirectUrl) {
+    Response(request, request.content.clientId) {
     val requestedVcPresentationSubmissionMap: RequestedVcPresentationSubmissionMap = mutableMapOf()
 }
 

--- a/sdk/src/main/java/com/microsoft/did/sdk/credential/service/models/oidc/PresentationRequestContent.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/credential/service/models/oidc/PresentationRequestContent.kt
@@ -16,11 +16,9 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class PresentationRequestContent(
-    // what type of object the response should be (should be idtoken). // TODO: validate
     @SerialName("response_type")
     val responseType: String = "",
 
-    // what mode the response should be sent in (should always be form post). // TODO: validate
     @SerialName("response_mode")
     val responseMode: String = "",
 
@@ -33,7 +31,6 @@ data class PresentationRequestContent(
     @SerialName("iss")
     val issuer: String = "",
 
-    // should contain "openid did_authn" // TODO: validate
     val scope: String = "",
 
     val state: String = "",

--- a/sdk/src/main/java/com/microsoft/did/sdk/credential/service/validators/OidcPresentationRequestValidator.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/credential/service/validators/OidcPresentationRequestValidator.kt
@@ -20,8 +20,8 @@ import javax.inject.Singleton
 class OidcPresentationRequestValidator @Inject constructor() : PresentationRequestValidator {
 
     override suspend fun validate(request: PresentationRequest) {
-        //TODO: Check for response type once it is changed to id_token
         checkResponseMode(request.content.responseMode)
+        checkResponseType(request.content.responseType)
         checkScope(request.content.scope)
         checkTokenExpiration(request.content.expirationTime)
         checkForInputInPresentationRequest(request)

--- a/sdk/src/test/java/com/microsoft/did/sdk/credential/service/validators/OidcPresentationRequestValidatorTest.kt
+++ b/sdk/src/test/java/com/microsoft/did/sdk/credential/service/validators/OidcPresentationRequestValidatorTest.kt
@@ -11,6 +11,10 @@ import com.microsoft.did.sdk.crypto.protocols.jose.jws.JwsToken
 import com.microsoft.did.sdk.identifier.models.Identifier
 import com.microsoft.did.sdk.util.Constants
 import com.microsoft.did.sdk.util.controlflow.ExpiredTokenExpirationException
+import com.microsoft.did.sdk.util.controlflow.InvalidResponseModeException
+import com.microsoft.did.sdk.util.controlflow.InvalidResponseTypeException
+import com.microsoft.did.sdk.util.controlflow.InvalidScopeException
+import com.microsoft.did.sdk.util.controlflow.MissingInputInRequestException
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -20,7 +24,6 @@ import kotlinx.serialization.json.Json
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import java.util.Date
-import kotlin.test.fail
 
 class OidcPresentationRequestValidatorTest {
 
@@ -37,15 +40,19 @@ class OidcPresentationRequestValidatorTest {
     private val expectedSerializedToken: String = "token2364302"
 
     private val validator: OidcPresentationRequestValidator = OidcPresentationRequestValidator()
-    
-	private val serializer: Json = Json
+
+    private val serializer: Json = Json
 
     private val expectedSigningKeyRef: String = "sigKeyRef1243523"
     private val expectedDid: String = "did:test:2354543"
-    private val expectedResponseType = "id_token"
-    private val expectedResponseMode = "form_post"
-    private val expectedScope = "openid did_authn"
+    private val expectedValidResponseType = "id_token"
+    private val expectedValidResponseMode = "form_post"
+    private val expectedValidScope = "openid did_authn"
     private val expectedExpirationTime = 86400L
+
+    private val expectedInvalidResponseMode = "invalid_response_mode"
+    private val expectedInvalidResponseType = "invalid_response_type"
+    private val expectedInvalidScope = "invalid_scope"
 
     init {
         setUpPresentationRequest()
@@ -68,10 +75,28 @@ class OidcPresentationRequestValidatorTest {
         every { mockedOidcRequestContent.expirationTime } returns currentTimePlusOffsetInSeconds
     }
 
-    private fun setUpOidcRequestContent() {
-        every { mockedOidcRequestContent.responseType } returns expectedResponseType
-        every { mockedOidcRequestContent.responseMode } returns expectedResponseMode
-        every { mockedOidcRequestContent.scope } returns expectedScope
+    private fun setUpOidcRequestContentWithValidFields() {
+        every { mockedOidcRequestContent.responseType } returns expectedValidResponseType
+        every { mockedOidcRequestContent.responseMode } returns expectedValidResponseMode
+        every { mockedOidcRequestContent.scope } returns expectedValidScope
+    }
+
+    private fun setUpOidcRequestContentWithInvalidResponseMode() {
+        every { mockedOidcRequestContent.responseType } returns expectedValidResponseType
+        every { mockedOidcRequestContent.responseMode } returns expectedInvalidResponseMode
+        every { mockedOidcRequestContent.scope } returns expectedValidScope
+    }
+
+    private fun setUpOidcRequestContentWithInvalidResponseType() {
+        every { mockedOidcRequestContent.responseType } returns expectedInvalidResponseType
+        every { mockedOidcRequestContent.responseMode } returns expectedValidResponseMode
+        every { mockedOidcRequestContent.scope } returns expectedValidScope
+    }
+
+    private fun setUpOidcRequestContentWithInvalidScope() {
+        every { mockedOidcRequestContent.responseType } returns expectedValidResponseType
+        every { mockedOidcRequestContent.responseMode } returns expectedValidResponseMode
+        every { mockedOidcRequestContent.scope } returns expectedInvalidScope
     }
 
     @Test
@@ -79,7 +104,7 @@ class OidcPresentationRequestValidatorTest {
         setUpExpiration(86400)
         every { mockedPresentationRequest.getPresentationDefinition().credentialPresentationInputDescriptors } returns listOf(mockk())
         every { mockedPresentationRequest.content } returns mockedOidcRequestContent
-        setUpOidcRequestContent()
+        setUpOidcRequestContentWithValidFields()
         every { JwsToken.deserialize(expectedSerializedToken, serializer) } returns mockedJwsToken
         coEvery { mockedJwtValidator.verifySignature(mockedJwsToken) } returns true
         runBlocking {
@@ -90,15 +115,74 @@ class OidcPresentationRequestValidatorTest {
     @Test
     fun `throws when token expiration is expired`() {
         setUpExpiration(-86400)
-        setUpOidcRequestContent()
+        setUpOidcRequestContentWithValidFields()
         every { JwsToken.deserialize(expectedSerializedToken, serializer) } returns mockedJwsToken
         coEvery { mockedJwtValidator.verifySignature(mockedJwsToken) } returns true
         runBlocking {
             try {
                 validator.validate(mockedPresentationRequest)
-                fail()
             } catch (exception: Exception) {
                 assertThat(exception).isInstanceOf(ExpiredTokenExpirationException::class.java)
+            }
+        }
+    }
+
+    @Test
+    fun `throws when request has invalid response mode`() {
+        setUpExpiration(86400)
+        every { mockedPresentationRequest.getPresentationDefinition().credentialPresentationInputDescriptors } returns listOf(mockk())
+        every { mockedPresentationRequest.content } returns mockedOidcRequestContent
+        setUpOidcRequestContentWithInvalidResponseMode()
+        runBlocking {
+            try {
+                validator.validate(mockedPresentationRequest)
+            } catch (exception: Exception) {
+                assertThat(exception).isInstanceOf(InvalidResponseModeException::class.java)
+            }
+        }
+    }
+
+    @Test
+    fun `throws when request has invalid response type`() {
+        setUpExpiration(86400)
+        every { mockedPresentationRequest.getPresentationDefinition().credentialPresentationInputDescriptors } returns listOf(mockk())
+        every { mockedPresentationRequest.content } returns mockedOidcRequestContent
+        setUpOidcRequestContentWithInvalidResponseType()
+        runBlocking {
+            try {
+                validator.validate(mockedPresentationRequest)
+            } catch (exception: Exception) {
+                assertThat(exception).isInstanceOf(InvalidResponseTypeException::class.java)
+            }
+        }
+    }
+
+    @Test
+    fun `throws when request has invalid scope`() {
+        setUpExpiration(86400)
+        every { mockedPresentationRequest.getPresentationDefinition().credentialPresentationInputDescriptors } returns listOf(mockk())
+        every { mockedPresentationRequest.content } returns mockedOidcRequestContent
+        setUpOidcRequestContentWithInvalidScope()
+        runBlocking {
+            try {
+                validator.validate(mockedPresentationRequest)
+            } catch (exception: Exception) {
+                assertThat(exception).isInstanceOf(InvalidScopeException::class.java)
+            }
+        }
+    }
+
+    @Test
+    fun `throws when request has missing input`() {
+        setUpExpiration(86400)
+        every { mockedPresentationRequest.getPresentationDefinition().credentialPresentationInputDescriptors } returns emptyList()
+        every { mockedPresentationRequest.content } returns mockedOidcRequestContent
+        setUpOidcRequestContentWithValidFields()
+        runBlocking {
+            try {
+                validator.validate(mockedPresentationRequest)
+            } catch (exception: Exception) {
+                assertThat(exception).isInstanceOf(MissingInputInRequestException::class.java)
             }
         }
     }


### PR DESCRIPTION
Redirect_uri in the request was being used to send response to. Changes involve sending the response to client_id and added validation for response type. Added unit tests for invalid inputs in oidc request.


**Validation:**
All automated tests pass.


**Type of change:**
- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.