### PR TITLE
fixing tests that is breaking when upgrading kotlin version

### DIFF
--- a/sdk/src/test/java/com/microsoft/did/sdk/IssuanceServiceTest.kt
+++ b/sdk/src/test/java/com/microsoft/did/sdk/IssuanceServiceTest.kt
@@ -27,11 +27,11 @@ import com.microsoft.did.sdk.identifier.resolvers.Resolver
 import com.microsoft.did.sdk.util.Constants
 import com.microsoft.did.sdk.util.controlflow.Result
 import io.mockk.coEvery
-import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkConstructor
 import io.mockk.spyk
+import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -143,10 +143,10 @@ class IssuanceServiceTest {
         val issuanceResponse = IssuanceResponse(issuanceRequest)
         val requestedVcMap = mapOf(mockk<PresentationAttestation>() to expectedVerifiableCredential) as RequestedVcMap
 
-        coEvery { issuanceService["exchangeVcsInIssuanceRequest"](issuanceResponse, pairwiseIdentifier) } returns Result.Success(
+        every { issuanceService["exchangeVcsInIssuanceRequest"](issuanceResponse, pairwiseIdentifier) } returns Result.Success(
             requestedVcMap
         )
-        coEvery {
+        every {
             issuanceService["formAndSendResponse"](
                 issuanceResponse,
                 pairwiseIdentifier,
@@ -165,7 +165,7 @@ class IssuanceServiceTest {
             assertThat(createdVerifiableCredential.payload.contents).isEqualTo(suppliedVcContent)
         }
 
-        coVerify(exactly = 1) {
+        verify(exactly = 1) {
             issuanceService["exchangeVcsInIssuanceRequest"](issuanceResponse, pairwiseIdentifier)
             issuanceService["formAndSendResponse"](
                 issuanceResponse,

--- a/sdk/src/test/java/com/microsoft/did/sdk/LinkedDomainsServiceTest.kt
+++ b/sdk/src/test/java/com/microsoft/did/sdk/LinkedDomainsServiceTest.kt
@@ -12,6 +12,7 @@ import com.microsoft.did.sdk.identifier.models.identifierdocument.IdentifierResp
 import com.microsoft.did.sdk.identifier.resolvers.Resolver
 import com.microsoft.did.sdk.util.controlflow.Result
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import kotlinx.coroutines.runBlocking
@@ -39,7 +40,7 @@ class LinkedDomainsServiceTest {
         val expectedWellKnownConfigDocument = defaultTestSerializer.decodeFromString(LinkedDomainsResponse.serializer(), expectedWellKnownConfigDocumentResponse)
         val expectedDomainUrl = "https://issuertestng.com"
         coEvery { mockedResolver.resolve(suppliedDidWithSingleServiceEndpoint) } returns Result.Success(expectedResponse.didDocument)
-        coEvery { linkedDomainsService["getWellKnownConfigDocument"](expectedDomainUrl) } returns Result.Success(expectedWellKnownConfigDocument)
+        every { linkedDomainsService["getWellKnownConfigDocument"](expectedDomainUrl) } returns Result.Success(expectedWellKnownConfigDocument)
         coEvery { mockedJwtValidator.verifySignature(any()) } returns true
         coEvery { mockedJwtValidator.validateDidInHeaderAndPayload(any(), any()) } returns true
         runBlocking {
@@ -60,7 +61,7 @@ class LinkedDomainsServiceTest {
         val expectedWellKnownConfigDocument = defaultTestSerializer.decodeFromString(LinkedDomainsResponse.serializer(), expectedWellKnownConfigDocumentResponse)
         val expectedDomainUrl = "https://issuertestng.com"
         coEvery { mockedResolver.resolve(suppliedDidWithMultipleServiceEndpoints) } returns Result.Success(expectedResponse.didDocument)
-        coEvery { linkedDomainsService["getWellKnownConfigDocument"](expectedDomainUrl) } returns Result.Success(expectedWellKnownConfigDocument)
+        every { linkedDomainsService["getWellKnownConfigDocument"](expectedDomainUrl) } returns Result.Success(expectedWellKnownConfigDocument)
         coEvery { mockedJwtValidator.verifySignature(any()) } returns true
         coEvery { mockedJwtValidator.validateDidInHeaderAndPayload(any(), any()) } returns true
         runBlocking {


### PR DESCRIPTION
Some mocking in tests were failing on kotlin version after 1.4.10. Fixed the tests.


**Validation:**
Verified that automated tests pass in kotlin version 1.4.20


**Type of change:**
- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [x] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.