### PR TITLE
use url class instead of string to handle domain urls

### DIFF
--- a/sdk/src/main/java/com/microsoft/did/sdk/datasource/network/BaseNetworkOperation.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/datasource/network/BaseNetworkOperation.kt
@@ -12,9 +12,11 @@ import com.microsoft.did.sdk.util.controlflow.ForbiddenException
 import com.microsoft.did.sdk.util.controlflow.LocalNetworkException
 import com.microsoft.did.sdk.util.controlflow.NetworkException
 import com.microsoft.did.sdk.util.controlflow.NotFoundException
+import com.microsoft.did.sdk.util.controlflow.RedirectException
 import com.microsoft.did.sdk.util.controlflow.Result
 import com.microsoft.did.sdk.util.controlflow.ServiceUnreachableException
 import com.microsoft.did.sdk.util.controlflow.UnauthorizedException
+import com.microsoft.did.sdk.util.log.SdkLog
 import retrofit2.Response
 import java.io.IOException
 
@@ -54,54 +56,61 @@ abstract class BaseNetworkOperation<S, T> {
         val requestId = response.headers()[REQUEST_ID_HEADER]
         val correlationVector = response.headers()[CORRELATION_VECTOR_HEADER]
         return when (response.code()) {
+            301, 302, 308 -> {
+                val errorMessage = StringBuilder("Redirecting is disabled: Http code: ${response.code()}\t")
+                if (response.errorBody() != null)
+                    errorMessage.append("ErrorBody: ${response.errorBody()?.string()}")
+                SdkLog.d(errorMessage.toString())
+                Result.Failure(RedirectException(response.code().toString(), response.errorBody()?.string() ?: "", false))
+            }
             401 -> Result.Failure(
                 UnauthorizedException(
-                    requestId,
-                    correlationVector,
                     response.code().toString(),
                     response.errorBody()?.string() ?: "",
-                    false
+                    false,
+                    requestId,
+                    correlationVector
                 )
             )
             402 -> Result.Failure(
                 ClientException(
-                    requestId,
-                    correlationVector,
                     response.code().toString(),
                     response.errorBody()?.string() ?: "",
-                    false
+                    false,
+                    requestId,
+                    correlationVector
                 )
             )
             403 -> {
                 Result.Failure(
                     ForbiddenException(
-                        requestId,
-                        correlationVector,
                         response.code().toString(),
                         response.errorBody()?.string() ?: "",
-                        false
+                        false,
+                        requestId,
+                        correlationVector
                     )
                 )
             }
             404 -> Result.Failure(
                 NotFoundException(
-                    requestId,
-                    correlationVector,
                     response.code().toString(),
                     response.errorBody()?.string() ?: "",
-                    false
+                    false,
+                    requestId,
+                    correlationVector
                 )
             )
             500, 501, 502, 503 -> Result.Failure(
                 ServiceUnreachableException(
-                    requestId,
-                    correlationVector,
                     response.code().toString(),
                     response.errorBody()?.string() ?: "",
-                    true
+                    true,
+                    requestId,
+                    correlationVector
                 )
             )
-            else -> Result.Failure(NetworkException(requestId, correlationVector, response.code().toString(), "Unknown Status code", true))
+            else -> Result.Failure(NetworkException(response.code().toString(), "Unknown Status code", true, requestId, correlationVector))
         }
     }
 

--- a/sdk/src/main/java/com/microsoft/did/sdk/datasource/network/apis/LinkedDomainsApis.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/datasource/network/apis/LinkedDomainsApis.kt
@@ -6,9 +6,10 @@ import com.microsoft.did.sdk.credential.service.models.serviceResponses.LinkedDo
 import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Url
+import java.net.URI
 
 interface LinkedDomainsApis {
 
     @GET
-    suspend fun fetchWellKnownConfigDocument(@Url overrideUrl: String): Response<LinkedDomainsResponse>
+    suspend fun fetchWellKnownConfigDocument(@Url overrideUrl: URI): Response<LinkedDomainsResponse>
 }

--- a/sdk/src/main/java/com/microsoft/did/sdk/datasource/network/linkedDomainsOperations/FetchWellKnownConfigDocumentNetworkOperation.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/datasource/network/linkedDomainsOperations/FetchWellKnownConfigDocumentNetworkOperation.kt
@@ -10,11 +10,20 @@ import com.microsoft.did.sdk.datasource.network.GetNetworkOperation
 import com.microsoft.did.sdk.datasource.network.apis.ApiProvider
 import com.microsoft.did.sdk.util.Constants
 import retrofit2.Response
+import java.net.URL
 import javax.inject.Inject
 
 class FetchWellKnownConfigDocumentNetworkOperation @Inject constructor(val url: String, apiProvider: ApiProvider) :
     GetNetworkOperation<LinkedDomainsResponse, LinkedDomainsResponse>() {
 
     override val call: suspend () -> Response<LinkedDomainsResponse> =
-        { apiProvider.linkedDomainsApis.fetchWellKnownConfigDocument("$url/${Constants.WELL_KNOWN_CONFIG_DOCUMENT_LOCATION}") }
+        {
+            val contextPath = URL(url)
+            apiProvider.linkedDomainsApis.fetchWellKnownConfigDocument(
+                URL(
+                    contextPath,
+                    Constants.WELL_KNOWN_CONFIG_DOCUMENT_LOCATION
+                ).toURI()
+            )
+        }
 }

--- a/sdk/src/main/java/com/microsoft/did/sdk/util/controlflow/Exceptions.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/util/controlflow/Exceptions.kt
@@ -46,8 +46,6 @@ open class RevocationException(message: String? = null, cause: Throwable? = null
 open class ValidatorException(message: String, cause: Throwable? = null, retryable: Boolean = false) :
     SdkException(message, cause, retryable)
 
-class UnableToFetchWellKnownConfigDocument(message: String, cause: Throwable? = null, retryable: Boolean = false) : SdkException(message, cause, retryable)
-
 class InvalidSignatureException(message: String) : ValidatorException(message)
 
 class ExpiredTokenException(message: String) : ValidatorException(message)
@@ -70,16 +68,18 @@ class RegistrarException(message: String, cause: Throwable? = null) : SdkExcepti
 
 open class LocalNetworkException(message: String, cause: Throwable? = null) : SdkException(message, cause, true)
 
-open class NetworkException(val requestId: String? = null, val correlationVector: String? = null, errorCode: String, message: String, retryable: Boolean) : SdkException(message, null, retryable, errorCode)
+open class NetworkException(errorCode: String, message: String, retryable: Boolean, val requestId: String? = null, val correlationVector: String? = null) : SdkException(message, null, retryable, errorCode)
 
-class ServiceUnreachableException(requestId: String?, correlationVector: String?, errorCode: String, message: String, retryable: Boolean) : NetworkException(requestId, correlationVector, errorCode, message, retryable)
+class ServiceUnreachableException(errorCode: String, message: String, retryable: Boolean, requestId: String?, correlationVector: String?) : NetworkException(errorCode, message, retryable, requestId, correlationVector)
 
-open class ClientException(requestId: String?, correlationVector: String?, errorCode: String, message: String, retryable: Boolean) : NetworkException(requestId, correlationVector, errorCode, message, retryable)
+open class ClientException(errorCode: String, message: String, retryable: Boolean, requestId: String?, correlationVector: String?) : NetworkException(errorCode, message, retryable, requestId, correlationVector)
 
-class ForbiddenException(requestId: String?, correlationVector: String?, errorCode: String, message: String, retryable: Boolean) : ClientException(requestId, correlationVector, errorCode, message, retryable)
+class ForbiddenException(errorCode: String, message: String, retryable: Boolean, requestId: String?, correlationVector: String?) : ClientException(errorCode, message, retryable, requestId, correlationVector)
 
-class NotFoundException(requestId: String?, correlationVector: String?, errorCode: String, message: String, retryable: Boolean) : ClientException(requestId, correlationVector, errorCode, message, retryable)
+class NotFoundException(errorCode: String, message: String, retryable: Boolean, requestId: String?, correlationVector: String?) : ClientException(errorCode, message, retryable, requestId, correlationVector)
 
-class UnauthorizedException(requestId: String?, correlationVector: String?, errorCode: String, message: String, retryable: Boolean) : NetworkException(requestId, correlationVector, errorCode, message, retryable)
+class UnauthorizedException(errorCode: String, message: String, retryable: Boolean, requestId: String?, correlationVector: String?) : NetworkException(errorCode, message, retryable, requestId, correlationVector)
+
+class RedirectException(errorCode: String, message: String, retryable: Boolean) : NetworkException(errorCode, message, retryable)
 
 class RepositoryException(message: String, cause: Throwable? = null) : SdkException(message, cause)

--- a/sdk/src/test/java/com/microsoft/did/sdk/datasource/repository/IdentifierRepositoryTest.kt
+++ b/sdk/src/test/java/com/microsoft/did/sdk/datasource/repository/IdentifierRepositoryTest.kt
@@ -115,11 +115,11 @@ class IdentifierRepositoryTest {
         mockkConstructor(ResolveIdentifierNetworkOperation::class)
         coEvery { anyConstructed<ResolveIdentifierNetworkOperation>().fire() } returns Result.Failure(
             NotFoundException(
-                "123",
-                "paMxWRuFSV+mo+Hso8IBVw.0",
                 "404",
                 "Not found",
-                true
+                true,
+                "123",
+                "paMxWRuFSV+mo+Hso8IBVw.0"
             )
         )
         runBlocking {

--- a/sdk/src/test/java/com/microsoft/did/sdk/identifier/resolvers/ResolverTest.kt
+++ b/sdk/src/test/java/com/microsoft/did/sdk/identifier/resolvers/ResolverTest.kt
@@ -40,11 +40,11 @@ class ResolverTest {
         val resolver = Resolver("", identifierRepository)
         coEvery { identifierRepository.resolveIdentifier("", invalidIdentifier) } returns Result.Failure(
             NotFoundException(
-                "123",
-                "paMxWRuFSV+mo+Hso8IBVw.0",
                 "404",
                 "Not Found",
-                true
+                true,
+                "123",
+                "paMxWRuFSV+mo+Hso8IBVw.0"
             )
         )
         runBlocking {


### PR DESCRIPTION
**Problem:**
When there is / at the end of domain urls, fetching document from that location was failing.


**Solution:**
Used URL class to handle the domain urls which takes care of those implicitly.


**Validation:**
Please include here how it was verified that the PR works as intended.


**Type of change:**
- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.