### PR TITLE
Don't catch CancelationExceptions

### DIFF
--- a/sdk/src/main/java/com/microsoft/did/sdk/util/controlflow/Result.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/util/controlflow/Result.kt
@@ -6,6 +6,7 @@
 package com.microsoft.did.sdk.util.controlflow
 
 import com.microsoft.did.sdk.util.log.SdkLog
+import kotlinx.coroutines.CancellationException
 
 typealias Success = Boolean
 
@@ -37,6 +38,8 @@ suspend fun <T> runResultTry(block: suspend RunResultTryContext.() -> Result<T>)
         RunResultTryContext().block()
     } catch (ex: RunResultTryAbortion) {
         Result.Failure(ex.error as SdkException)
+    } catch (ex: CancellationException) {
+        throw ex
     } catch (ex: SdkException) {
         SdkLog.w("Internal Sdk Exception", ex)
         Result.Failure(ex)


### PR DESCRIPTION
Cancelations should not be catched as they are used by coroutines internally. 

Part of the fix for KotlinNullPointerException in our load and completion fragments

**Type of change:**
- [ ] Feature work
- [X] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [X] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)