### PR TITLE
Disabled logo size check temporarily

### DIFF
--- a/sdk/src/main/java/com/microsoft/did/sdk/internal/ImageLoader.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/internal/ImageLoader.kt
@@ -28,8 +28,9 @@ class ImageLoader @Inject constructor() {
 
     private suspend fun loadImageToBase64(uri: String): String = withContext(Dispatchers.IO) {
         val imageBitmap = Picasso.get().load(uri).get()
-        if (imageBitmap.byteCount > MAX_IMAGE_SIZE_BYTES)
-            throw InvalidImageException("Image size exceeds max file size ${MAX_IMAGE_SIZE_BYTES / 1000000.0f}MB")
+        // TODO: check is temporarily disabled because file size is not matching bytecount by order of magnitues sometimes
+//        if (imageBitmap.byteCount > MAX_IMAGE_SIZE_BYTES)
+//            throw InvalidImageException("Image size exceeds max file size ${MAX_IMAGE_SIZE_BYTES / 1000000.0f}MB")
         return@withContext ImageUtil.convert(imageBitmap)
     }
 }


### PR DESCRIPTION
check is temporarily disabled because file size is not matching bytecount by order of magnitues sometimes


**Type of change:**
- [ ] Feature work
- [ ] Bug fix
- [ ] Documentation
- [X] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [X] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.