### PR TITLE
don't fail if pin is missing in idtokenhint during validation

### DIFF
--- a/sdk/src/main/java/com/microsoft/did/sdk/credential/service/validators/OidcPresentationRequestValidator.kt
+++ b/sdk/src/main/java/com/microsoft/did/sdk/credential/service/validators/OidcPresentationRequestValidator.kt
@@ -71,10 +71,13 @@ class OidcPresentationRequestValidator @Inject constructor(private val jwtValida
         if (!jwtValidator.verifySignature(jwsToken))
             throw InvalidSignatureException("Signature is not valid on id token hint.")
         val json = Json.decodeFromString(JsonObject.serializer(), jwsToken.content())
-        val pinObject = json["pin"] as? JsonObject ?: throw InvalidPinDetailsException("PIN details is missing in request.")
-        val length = (pinObject["length"] as? JsonPrimitive)?.content?.toInt() ?: throw InvalidPinDetailsException("PIN length is missing in request.")
-        val type = (pinObject["type"] as? JsonPrimitive)?.content ?: throw InvalidPinDetailsException("PIN type is missing in request.")
-        if (length < 1) throw InvalidPinDetailsException("PIN length is invalid in request.")
-        if (!(type == "numeric" || type == "text")) throw InvalidPinDetailsException("PIN type is invalid in request.")
+        val pinObject = json["pin"] as? JsonObject
+        if (pinObject != null) {
+            val length = (pinObject["length"] as? JsonPrimitive)?.content?.toInt()
+                ?: throw InvalidPinDetailsException("PIN length is missing in request.")
+            val type = (pinObject["type"] as? JsonPrimitive)?.content ?: throw InvalidPinDetailsException("PIN type is missing in request.")
+            if (length < 1) throw InvalidPinDetailsException("PIN length is invalid in request.")
+            if (!(type == "numeric" || type == "text")) throw InvalidPinDetailsException("PIN type is invalid in request.")
+        }
     }
 }


### PR DESCRIPTION
**Problem:**
If "pin" missing in "idTokenHint", request was failing due to the validation on "pin" field.


**Solution:**
Not throw an exception if pin is missing as it is an optional field.


**Validation:**
Please include here how it was verified that the PR works as intended.


**Type of change:**
- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
Please include here links for this work item, or deferred work, or related work. E.g. if the refactoring is too big to fit in this PR, or the localized strings need to be updated later, please link the TODO work items here.


**Documentation Links**:
Please include here links to any related background documentation for this PR.