### PR TITLE
Change sub-project dir name to lowercase

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
-include ':SDK'
+include ':sdk'
 rootProject.name='VerifiableCredential-SDK'


### PR DESCRIPTION
**Problem:**

In the Linux environment, directory names are case-sensitive, so gradle cannot be included sub-project(sdk) unless they match the actual directory name (lowercase).


**Solution:**

Change the directory name of sub-project in `settings.gradle` to lowercase.


**Validation:**

In the Linux environment, verify that the sub-project is included.


**Type of change:**
- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:

**Documentation Links**: