### PR TITLE
Bump room version to fix m1 compilation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ target_sdk_version=31
 
 ndk_version=21.3.6528147
 dagger_version=2.42
-androidx_room_persistence_version=2.2.6
+androidx_room_persistence_version=2.4.3
 androidx_preference_version=1.1.1
 retrofit2_version=2.9.0
 com_squareup_okhttp3_okhttp_version=4.9.1


### PR DESCRIPTION
**Problem:**
SDK Fails to build on M1 macs with output
`No Native library is found for os.name=Mac and os.arc=aarch64. path=/org/sqlite/native/Mac/aarch64`


**Solution:**
This was fixed in room version [2.4.0-alpha03](https://developer.android.com/jetpack/androidx/releases/room#2.4.0-alpha03).  
Bump to latest stable version


**Validation:**
Compilation succeeds.  A single test fails in `ClaimFormatterTest.test formatting date and time successfully`.  I have verified on a non M1 mac, before this change, that the test also failed on latest main branch version

**Type of change:**
- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry


**Risk**:
- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [ ] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [x] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)


**Work Item links**:
#223 


**Documentation Links**:
[2.4.0-alpha03](https://developer.android.com/jetpack/androidx/releases/room#2.4.0-alpha03)
`Fixed an issue with Room’s SQLite native library to support Apple’s M1 chips.`[b/174695268](https://issuetracker.google.com/issues/174695268?pli=1)